### PR TITLE
Take a better approach to scaling using normalized (log(x)) formula.

### DIFF
--- a/src/viz.c
+++ b/src/viz.c
@@ -155,16 +155,18 @@ extern int layout_graph(igraph_t *graph, char layout) {
 extern int set_size(igraph_t *graph, igraph_vector_t *v, int max) {
   long int gsize = (long int)igraph_vcount(graph);
   igraph_vector_t v2;
-  igraph_vector_t min;
+  igraph_vector_t logOf;
+  igraph_vector_init(&logOf, gsize);
   double scale;
   igraph_vector_copy(&v2, v);
-  igraph_vector_init(&min, gsize);
-  igraph_vector_fill(&min, igraph_vector_min(&v2));
-  igraph_vector_sub(&v2, &min);
-  scale = log10(gsize / (igraph_vector_max(&v2) - igraph_vector_min(&v2)));
-  igraph_vector_scale(&v2, scale);
-  SETVANV(graph, "size", &v2);
+  for (long int i=0; i<gsize; i++){
+    double val = log(VECTOR(v2)[i] + 1);
+    double minimum = log(igraph_vector_min(&v2) + 1);
+    double maximum = log(igraph_vector_max(&v2) + 1);
+    VECTOR(logOf)[i] = (max * (val - minimum) / (maximum - minimum));
+  }
+  SETVANV(graph, "size", &logOf);
+  igraph_vector_destroy(&logOf);
   igraph_vector_destroy(&v2);
-  igraph_vector_destroy(&min);
   return 0;
 }

--- a/tests/quickrun_test.c
+++ b/tests/quickrun_test.c
@@ -64,7 +64,7 @@ void TEST_QUICKRUN_COLOR() {
 void TEST_QUICKRUN_SIZE() {
   quickrunGraph();
   igraph_vector_t size;
-  igraph_vector_init(&size, 0);
+  igraph_vector_init(&size, 0.0);
   VANV(&g, "size", &size);
   TEST_ASSERT_EQUAL_FLOAT(VECTOR(size)[0], 0.0);
   TEST_ASSERT_EQUAL_FLOAT(VECTOR(size)[10], 0.0);


### PR DESCRIPTION
**GitHub issue(s)**:

If you are responding to an issue, please mention their numbers below.

#45 & #25

# What does this Pull Request do?

Taking the approach described in detail in #25, creates a more attractive output for gexf graphs out of the box (more closely connected to the promise outlined in the README.md).

# How should this be tested?
`make clean all` should pass all tests.
`./graphpass --dir {enter filepath if file is not in /assets} --file {enter test graphml filename} -qg`
should put a gexf copy of the graphml in /OUT
Test file in Gephi.
Test file in SigmaJS / auk.

# Additional Notes:

This approach may change the default output in SigmaJS, having impacts in auk. While the changes should be minor, we will need to look out for:  
1 - wonky node sizing issues (similar to #25)
2 - the graph being overrun with text due to more equitable approach to nodesizes.
3 - that the aesthetics generally work for an auk output.
4 - that the scaling up/down feature in auk is a) still working okay and b) still useful.

# Interested parties

@ianmilligan1 @ruebot

Thanks in advance for your help with the Archives Unleashed Project!
