### PR TITLE
Update language from library to utility, resolving #52

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         = 0.0.2
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "A helper library for network filtering, analysis and visualization"
+PROJECT_BRIEF          = "A utility for network filtering, analysis and visualization"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ![GraphPass in action](https://user-images.githubusercontent.com/3834704/35356808-87152cf0-011f-11e8-9264-9c411ca16b3e.png)
 
-GraphPass is a helper library to filter networks and provide a default
+GraphPass is a utility to filter networks and provide a default
 visualization output for [Gephi](https://gephi.org/) or [SigmaJS](https://sigmaja.org). It prevents the infamous "borg cube" result when entering large files into Gephi, allowing you to work with ready-made network layouts.
 
 ## Installation
 
 ### Dependencies
 
-This library requires the [C Igraph Library](http://igraph.org/c/) and
+This utility requires the [C Igraph Library](http://igraph.org/c/) and
 a C compiler, such as [gcc](https://gcc.gnu.org/).
 
 #### For Linux (Ubuntu):


### PR DESCRIPTION
This updates the README and the documentation file to reflect discussion in #52. It is now referred to as a "utility" rather than a "helper library."

Should be a straightforward merge if this looks good to you, @greebie. 