### PR TITLE
Quit graphpass on graph with > 1000000 edges in the graph.

### DIFF
--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -79,7 +79,7 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
 #define PAGERANK_DAMPING 0.85 /**< chance random walk will not restart */
 #define LAYOUT_DEFAULT_CHAR 'f'
 #define MAX_NODES 50000 /**< default number of nodes in graph before shut down */
-#define MAX_EDGES 1000000 /**< default number of edges in graph before shut down */
+#define MAX_EDGES 500000 /**< default number of edges in graph before shut down */
 #define MAX_USER_EDGES 1000000000
 #define MAX_USER_NODES 1000000000
 

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -40,6 +40,7 @@ char* ug_methods;  /**< METHODS to filter */
 char* ug_OUTPUT;  /**< Folder to output new graphs */
 char* OUTPATH; /**< Path to output folder (DIRECTORY + OUTPUT) */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
+igraph_integer_t EDGESIZE; /**< Number of Edges in origianl graph */
 float ug_percent; /**< Filtering percentage 0.0 by default */
 bool ug_report; /**< Include a report? */
 bool ug_gformat; /**< Graph format - true is "GEXF" false is "GRAPHML" */
@@ -76,6 +77,7 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
 #define PAGERANK_DAMPING 0.85 /**< chance random walk will not restart */
 #define LAYOUT_DEFAULT_CHAR 'f'
 #define MAX_NODES 50000 /**< number of nodes in graph before shut down */
+#define MAX_EDGES 1000000 /**< number of edges in graph before shut down */
 
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -40,7 +40,7 @@ char* ug_methods;  /**< METHODS to filter */
 char* ug_OUTPUT;  /**< Folder to output new graphs */
 char* OUTPATH; /**< Path to output folder (DIRECTORY + OUTPUT) */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
-igraph_integer_t EDGESIZE; /**< Number of Edges in origianl graph */
+igraph_integer_t EDGESIZE; /**< Number of Edges in original graph */
 float ug_percent; /**< Filtering percentage 0.0 by default */
 long ug_maxnodes; /**< user-defined max nodes for processing, default MAX_NODES */
 long ug_maxedges; /**< user-defined maxiumum edges for processing default MAX_EDGES */

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -42,6 +42,8 @@ char* OUTPATH; /**< Path to output folder (DIRECTORY + OUTPUT) */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
 igraph_integer_t EDGESIZE; /**< Number of Edges in origianl graph */
 float ug_percent; /**< Filtering percentage 0.0 by default */
+long ug_maxnodes; /**< user-defined max nodes for processing, default MAX_NODES */
+long ug_maxedges; /**< user-defined maxiumum edges for processing default MAX_EDGES */
 bool ug_report; /**< Include a report? */
 bool ug_gformat; /**< Graph format - true is "GEXF" false is "GRAPHML" */
 bool ug_quickrun; /**< Lightweight visualization run */
@@ -76,8 +78,10 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
 #define COLOR_BASE "WalkTrapModularity"
 #define PAGERANK_DAMPING 0.85 /**< chance random walk will not restart */
 #define LAYOUT_DEFAULT_CHAR 'f'
-#define MAX_NODES 50000 /**< number of nodes in graph before shut down */
-#define MAX_EDGES 1000000 /**< number of edges in graph before shut down */
+#define MAX_NODES 50000 /**< default number of nodes in graph before shut down */
+#define MAX_EDGES 1000000 /**< default number of edges in graph before shut down */
+#define MAX_USER_EDGES 1000000000
+#define MAX_USER_NODES 1000000000
 
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -58,24 +58,26 @@ int main (int argc, char *argv[]) {
     {
       static struct option long_options[] =
         {
-          /* These options don’t set a flag.
-             We distinguish them by their indices. */
-          {"verbose", no_argument,       0, 'v'},
-          {"no-save", no_argument,       0, 'n'},
-          {"report",  no_argument,       0, 'r'},
+          /* These options have no required argument */
           {"gexf",    no_argument,       0, 'g'},
+          {"no-save", no_argument,       0, 'n'},
+          {"verbose", no_argument,       0, 'v'},
           {"quick",   no_argument,       0, 'q'},
-          {"weighted",no_argument,       0, 'w'},
+          {"report",  no_argument,       0, 'r'},
+
+          /* These options require an argument */
+          {"dir",     required_argument, 0, 'd'},
           {"file",    required_argument, 0, 'f'},
-          {"percent", required_argument, 0, 'p'},
           {"methods", required_argument, 0, 'm'},
           {"output",  required_argument, 0, 'o'},
-          {"dir",     required_argument, 0, 'd'},
+          {"percent", required_argument, 0, 'p'},
+          {"max-nodes", required_argument, 0, 'x'},
+          {"max-edges", required_argument, 0, 'y'},
           {0, 0, 0, 0}
         };
       /* getopt_long stores the option index here. */
       int option_index = 0;
-      c = getopt_long (argc, argv, "vnrgqwf:p:m:o:d",
+      c = getopt_long (argc, argv, "gnvqrd:f:m:o:p:x:y:",
                        long_options, &option_index);
 
       /* Detect the end of the options. */
@@ -121,6 +123,12 @@ int main (int argc, char *argv[]) {
         case 'w':
           CALC_WEIGHTS = !CALC_WEIGHTS;
           break;
+        case 'x':
+          ug_maxnodes = optarg ? (long)strtol(optarg, (char**)NULL, 10) : MAX_NODES;
+          break;
+        case 'y':
+          ug_maxedges = optarg ? (long)strtol(optarg, (char**)NULL, 10) : MAX_EDGES;
+          break;
         case '?':
           /* getopt_long already printed an error message. */
           break;
@@ -139,6 +147,8 @@ int main (int argc, char *argv[]) {
     }
 
   /** set default values if not included in flags **/
+  ug_maxnodes = ug_maxnodes ? ug_maxnodes : MAX_NODES;
+  ug_maxedges = ug_maxedges ? ug_maxedges : MAX_EDGES;
   ug_OUTPUT = ug_OUTPUT ? ug_OUTPUT : "OUT/";
   ug_percent = ug_percent ? ug_percent : 0.00;
   ug_methods = ug_methods ? ug_methods : "d";
@@ -176,9 +186,9 @@ int main (int argc, char *argv[]) {
   }
   load_graph(FILEPATH);
   free(FILEPATH);
-  if (igraph_vcount(&g) > MAX_NODES || igraph_ecount(&g) > MAX_EDGES){
+  if (igraph_vcount(&g) > ug_maxnodes || igraph_ecount(&g) > ug_maxedges){
     printf ("FAIL >>> Graphpass can only conduct analysis on graphs with \
-    fewer than %i nodes and %i edges.\n", MAX_NODES, MAX_EDGES);
+fewer than %li nodes and %li edges.\n", ug_maxnodes, ug_maxedges);
     printf ("FAIL >>> Exiting...\n");
     exit(EXIT_FAILURE);
   }

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -176,8 +176,9 @@ int main (int argc, char *argv[]) {
   }
   load_graph(FILEPATH);
   free(FILEPATH);
-  if (igraph_vcount(&g) > MAX_NODES) {
-    printf ("FAIL >>> Graphpass can only conduct analysis on graphs with fewer than %i nodes.\n", MAX_NODES);
+  if (igraph_vcount(&g) > MAX_NODES || igraph_ecount(&g) > MAX_EDGES){
+    printf ("FAIL >>> Graphpass can only conduct analysis on graphs with \
+    fewer than %i nodes and %i edges.\n", MAX_NODES, MAX_EDGES);
     printf ("FAIL >>> Exiting...\n");
     exit(EXIT_FAILURE);
   }

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -46,8 +46,10 @@ extern int load_graph (char* filename) {
   }
   igraph_read_graph_graphml(&g, fp, 0);
   NODESIZE = igraph_vcount(&g);
+  EDGESIZE = igraph_ecount(&g);
   if (ug_verbose) {
-    printf("Successfully ingested graph with %li nodes.\n", (long int)NODESIZE);
+    printf("Successfully ingested graph with %li nodes and %li edges.\n"
+    , (long int)NODESIZE, (long int)EDGESIZE);
   }
   fclose(fp);
   return (0);
@@ -102,4 +104,3 @@ extern int write_graph(igraph_t *graph, char *attr) {
   }
   return 0;
 }
-


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**


#60 

# What does this Pull Request do?

Drops the graphpass job if the edges are greater than 1,000,000.

# How should this be tested?

Unfortunately, this may take some testing to be sure that we are happy with the 1,000,000 edge limit. For example, are there gexfs in our collection that do not potato browsers but yet have 1,000,000 or more edges?

You can use graphpass to get the edge count using the no-save and verbose flags (n & v):
`./graphpass -nv -f {FILENAME}`.  I will do a check myself, but thought I'd push this one in case someone else has time to check a few as well.

# Additional Notes:
This should cover the vast number of problems with files being too large. The only other potential future way we could have huge files is if labels or other data components were super-large.

I do not think we need to resolve this now, but it's worth mentioning for the future.

# Interested parties

@ianmilligan1 @ruebot 
