### PR TITLE
Implement stdin stdout procedures addressing Issue #47.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - cd $TRAVIS_BUILD_DIR
-  - make
+  - make clean all
   - ./graphpass
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get install -qq gcc-7 g++-7
+  - sudo apt-get install -qq gcc-7 g++-7 libnewlib-dev
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7
   - sudo update-alternatives --config gcc
   - cd /tmp && wget http://igraph.org/nightly/get/c/igraph-0.7.1.tar.gz && tar -xvzf igraph-0.7.1.tar.gz && cd igraph-0.7.1 && ./configure && make && sudo make install && sudo ldconfig

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ UNAME := $(shell uname)
 ifeq ($(UNAME), Linux)
   BASE_PATH = /usr/local/
   IGRAPH_PATH = $(BASE_PATH)
-	LIBGEN = -I/usr/include/libgen.h
+	LIBGEN = -I/usr/include/
 endif
 ifeq ($(UNAME), Darwin)
   IGRAPH_PATH = /usr/local/Cellar/igraph/0.7.1_6/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
-  IGRAPH_PATH = /usr/local/
+  BASE_PATH = /usr/local/
+  IGRAPH_PATH = $(BASE_PATH)
+	LIBGEN = -I/usr/include/libgen.h
 endif
 ifeq ($(UNAME), Darwin)
   IGRAPH_PATH = /usr/local/Cellar/igraph/0.7.1_6/
@@ -18,13 +20,13 @@ TEST_INCLUDE = ./src/tests/
 TEST_RUNNER_PATH = ./src/tests/
 UNITY_INCLUDE = ./vendor/unity
 INCLUDE = ./src/headers
-DEPS = -I$(INCLUDE) -I$(IGRAPH_INCLUDE) -I$(UNITY_INCLUDE)
+DEPS = -I$(INCLUDE) -I$(IGRAPH_INCLUDE) -I$(UNITY_INCLUDE) $(LIBGEN)
 BUILD = build/
 
 all: test install
 
 install: src/main/graphpass.c
-	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
+	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm -o graphpass
 	- ./graphpass -qnv
 
 release: src/main/graphpass.c
@@ -32,7 +34,7 @@ release: src/main/graphpass.c
 	- ./graphpass -qgnv
 
 debug: ./src/main/graphpass.c
-	gcc -g src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
+	gcc -g -Wall src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
 
 test: qp ana run clean
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: test install
 
 install: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
-	- ./graphpass -qnv
+	- ./graphpass -qnv src/resources/cpp2.graphml $(BUILD)
 
 release: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
@@ -51,4 +51,5 @@ clean:
 	rm -f qp
 	rm -f ana
 	rm -rf TEST_OUT_FOLDER
+	rm -rf $(BUILD)
 	rm -f graphpass

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ all: test install
 
 install: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
-	- ./graphpass -qnv src/resources/cpp2.graphml $(BUILD)
+	- ./graphpass -qnv
 
 release: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
-	- ./graphpass -qgv
+	- ./graphpass -qgnv
 
 debug: ./src/main/graphpass.c
 	gcc -g src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ all: test install
 
 install: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
-	- ./graphpass -qn
+	- ./graphpass -qnv
 
 release: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
-	- ./graphpass -qg
+	- ./graphpass -qgv
 
 debug: ./src/main/graphpass.c
 	gcc -g src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then
 
 ```
 cd graphpass
-make
+make clean all
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -94,18 +94,21 @@ make
 Once compiled use the following command:
 
 ```
-./graphpass {FLAGS}
+./graphpass {INPUT PATH} {OUTPUT PATH} {FLAGS}
 ```
 
 The following flags are available:
 
-* `--file {FILENAME}` - sets the default filename. If not set, `graphpass` will use
-a default network in `src/resources`.
-* `--dir {DIRECTORY}` - the path to look for {FILENAME} by default this is `src/resources/`
-* `--output {OUTPUT}` - the directory to send output files such as filtered graphs and data reports.
-* `--percent {PERCENT}` - a percentage to remove from the file.  By default this is 0.0.
-* `--method {options}` - a string of various methods through which to filter the
+* `--input {FILEPATH} or -i` - The filepath of the file to run Graphpass on. If not set, `graphpass` will use
+a default network in `src/resources`. This will override the value in `{INPUT PATH}`.
+* `--output {FILEPATH} or -o` - The filepath for outputs, overriding `{OUTPUT PATH}`. If the output path contains a filename, Graphpass will use that, otherwise it will default to the filename provided in `{INPUT PATH}`. Unless the quickpass (`-q`) is selected, the filename will also be altered to show the percentage filtered from the graph and the method used.
+* `--percent {PERCENT} or -p` - a percentage to remove from the file.  By default this is 0.0.
+* `--method {options} or -m` - a string of various methods through which to filter the
 graph.
+* `--quick or -q` - Graphpass will run a basic set of algorithms for visualization with no filtering. The filename will be the same as the input filename.
+* `--gexf or -g` - Graphpass will return the graph output in gexf (good for SigmaJS) instead of graphml.
+* `--max-nodes {Value}` - Change default maximum number of nodes that graphpass will accept. By default this is 50,000. Values larger than 50k may cause graphpass to use up a computer's memory.
+* `--max-edges {Value}` - Change default maximum number of edges that graphpass will accept. By default this is 500,000. Values larger than 500k are unlikely to cause significant delays in computation time, but could result in memory issue upon visualization in Gephi or SigmaJS.
 
 These various methods are outlined below:
 
@@ -122,17 +125,15 @@ These various methods are outlined below:
 For example:
 
 ```
-./graphpass --percent 10 --methods b --file links-for-gephi.graphml --output OUT/
+./graphpass /path/to/links-for-gephi.graphml --percent 10 --methods b /path/to/OUT/file
 ```
 
-Will remove 10% of the graph using betweenness as a cutting measure and lay the network out. It will find `links-for-gephi.graphml` file in `src/resources` and output a new one to `/OUT` (titled `links-for-gephi10Betweenness.graphml`).
+Will remove 10% of the graph using betweenness as a cutting measure and lay the network out. It will find `links-for-gephi.graphml` file in `path/to` and output a new one to `/path/to/OUT` (titled `fileBetweenness.graphml`).
 
 # Optional arguments
 
 * `--report` or `-r` : create an output report showing the impact of filtering on graph features.
 * `--no-save` or `-n` : does not save any filtered files (useful if you just want a report).
-* `--quick` or `-q` : provides a "quickrun" for basic
-* `--gexf` or `-g` : output as a .gexf (e.g. for SigmaJS inputs) instead of .graphml.
 
 # Troubleshooting
 

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -39,6 +39,7 @@ igraph_t g;
 igraph_attribute_table_t att;
 
 char* ug_OUT; /**< A FILEPATH called using -o flag */
+char* ug_OUTFILE; /**< A FILENAME for outputting */
 char* ug_INPUT; /** A FILEPATH called using -i flag */
 char* ug_FILENAME; /**< FILENAME extracted from stdin path */
 char* ug_PATH; /**< Directory path extracted from stdin path */

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -40,6 +40,7 @@ char* ug_methods;  /**< METHODS to filter */
 char* ug_OUTPUT;  /**< Folder to output new graphs */
 char* OUTPATH; /**< Path to output folder (DIRECTORY + OUTPUT) */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
+igraph_integer_t EDGESIZE; /**< Number of Edges in origianl graph */
 float ug_percent; /**< Filtering percentage 0.0 by default */
 bool ug_report; /**< Include a report? */
 bool ug_gformat; /**< Graph format - true is "GEXF" false is "GRAPHML" */
@@ -76,6 +77,7 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
 #define PAGERANK_DAMPING 0.85 /**< chance random walk will not restart */
 #define LAYOUT_DEFAULT_CHAR 'f'
 #define MAX_NODES 50000 /**< number of nodes in graph before shut down */
+#define MAX_EDGES 1000000 /**< number of edges in graph before shut down */
 
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -92,6 +92,11 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
 
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 
+struct Argument {
+  char* val;
+  struct Argument *next;
+};
+
 struct Node {
   char* abbrev;
   igraph_real_t val;
@@ -125,6 +130,7 @@ struct Node* clustering;
 struct Node* pv;
 struct Node* ts;
 struct RankNode* ranks;
+struct Argument* ug_args;
 
 int shuffle(int *array, int n);
 /** adds a new value to a Node **/
@@ -133,6 +139,7 @@ int push(struct Node** head_ref, igraph_real_t value, char* attr);
 /** adds a new value to a RankNode **/
 int pushRank (struct RankNode** head_ref, int rankids[20]);
 int igraph_i_xml_escape(char* src, char** dest);
+int pushArg (struct Argument** arg, char *value);
 
 int igraph_write_graph_gexf(const igraph_t *graph, FILE *outstream,
                             igraph_bool_t prefixattr);

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -30,17 +30,20 @@
 #include <unistd.h>
 #include <errno.h>
 #include <getopt.h>
+#include <libgen.h>
 
 typedef enum { false, true } bool;
 typedef enum { FAIL, WARN, COMM } broadcast;
 
 igraph_t g;
 igraph_attribute_table_t att;
-const char* ug_FILENAME; /**< The filename from -f flag. */
-const char* ug_DIRECTORY; /**< Directory to access FILENAME */
+
+char* ug_FILENAME; /**< FILENAME extracted from stdin path */
+char* ug_PATH; /**< Directory path extracted from stdin path */
 char* ug_methods;  /**< METHODS to filter */
-char* ug_OUTPUT;  /**< Folder to output new graphs */
-char* OUTPATH; /**< Path to output folder (DIRECTORY + OUTPUT) */
+char* ug_OUTPATH; /**< Path to output folder */
+char* ug_OUTPUT; /**< Filename extracted from outpath, if it exists. */
+char* ug_DIRECTORY; /**< Directory extracted from ug_PATH */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
 igraph_integer_t EDGESIZE; /**< Number of Edges in original graph */
 float ug_percent; /**< Filtering percentage 0.0 by default */

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -38,6 +38,8 @@ typedef enum { FAIL, WARN, COMM } broadcast;
 igraph_t g;
 igraph_attribute_table_t att;
 
+char* ug_OUT; /**< A FILEPATH called using -o flag */
+char* ug_INPUT; /** A FILEPATH called using -i flag */
 char* ug_FILENAME; /**< FILENAME extracted from stdin path */
 char* ug_PATH; /**< Directory path extracted from stdin path */
 char* ug_methods;  /**< METHODS to filter */

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -30,7 +30,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <getopt.h>
-#include <libgen.h>
 
 typedef enum { false, true } bool;
 typedef enum { FAIL, WARN, COMM } broadcast;
@@ -46,6 +45,7 @@ char* ug_PATH; /**< Directory path extracted from stdin path */
 char* ug_methods;  /**< METHODS to filter */
 char* ug_OUTPATH; /**< Path to output folder */
 char* ug_OUTPUT; /**< Filename extracted from outpath, if it exists. */
+char* ug_OUTARG; /**< Filepath entered as ARG */
 char* ug_DIRECTORY; /**< Directory extracted from ug_PATH */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
 igraph_integer_t EDGESIZE; /**< Number of Edges in original graph */
@@ -132,6 +132,8 @@ struct Node* pv;
 struct Node* ts;
 struct RankNode* ranks;
 struct Argument* ug_args;
+int get_directory (char *path, char **result);
+int get_filename (char *path, char **result);
 
 int shuffle(int *array, int n);
 /** adds a new value to a Node **/

--- a/src/main/gexf.c
+++ b/src/main/gexf.c
@@ -82,6 +82,7 @@ extern int igraph_write_graph_gexf(const igraph_t *graph, FILE *outstream,
   const char *gprefix= prefixattr ? "g_" : "";
   const char *vprefix= prefixattr ? "v_" : "";
   const char *eprefix= prefixattr ? "e_" : "";
+  printf("writing gexf");
 
   ret=fprintf(outstream, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\x0A");
   if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);

--- a/src/main/gexf.c
+++ b/src/main/gexf.c
@@ -82,7 +82,6 @@ extern int igraph_write_graph_gexf(const igraph_t *graph, FILE *outstream,
   const char *gprefix= prefixattr ? "g_" : "";
   const char *vprefix= prefixattr ? "v_" : "";
   const char *eprefix= prefixattr ? "e_" : "";
-  printf("writing gexf");
 
   ret=fprintf(outstream, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\x0A");
   if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -143,6 +143,9 @@ int main (int argc, char *argv[]) {
     ug_OUTPATH = ug_args->val;
     if (ug_args->next) {
       ug_PATH = ug_args->next->val;
+    } else {
+      ug_PATH = ug_OUTPATH;
+      ug_OUTPATH = NULL;
     }
   }
   ug_maxnodes = ug_maxnodes ? ug_maxnodes : MAX_NODES;
@@ -157,7 +160,7 @@ int main (int argc, char *argv[]) {
     ug_OUTFILE = (ug_OUTPATH[strlen(ug_OUTPATH)-1] != '/') ? basename(ug_OUTPATH) : ug_FILENAME;
     ug_OUTPATH = (ug_OUTPATH[strlen(ug_OUTPATH)-1] == '/') ? ug_OUTPATH : strncat(dirname(ug_OUTPATH), "/", 1);
   } else {
-    ug_OUTPATH = "OUT/";
+    ug_OUTPATH = "./OUT/";
     ug_OUTFILE = ug_FILENAME;
   }
 

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -158,7 +158,7 @@ int main (int argc, char *argv[]) {
   ug_DIRECTORY = FILEPATH ? dirname(FILEPATH) : "./";
   if (ug_OUTPATH) {
     ug_OUTFILE = (ug_OUTPATH[strlen(ug_OUTPATH)-1] != '/') ? basename(ug_OUTPATH) : ug_FILENAME;
-    ug_OUTPATH = (ug_OUTPATH[strlen(ug_OUTPATH)-1] == '/') ? ug_OUTPATH : strncat(dirname(ug_OUTPATH), "/", 1);
+    ug_OUTPATH = (ug_OUTPATH[strlen(ug_OUTPATH)-1] == '/') ? ug_OUTPATH : strncat(dirname(ug_OUTPATH), "/", 2);
   } else {
     ug_OUTPATH = "./OUT/";
     ug_OUTFILE = ug_FILENAME;

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -48,19 +48,9 @@ bool ug_quickrun = false;
 /** Print out helper messages **/
 bool ug_verbose = false;
 const char hyphen = '-';
-char check1;
-char check2;
+char* checkHyphen;
 
 int main (int argc, char *argv[]) {
-  check1 = argv[1] ? argv[1][0] : hyphen;
-  check2 = argv[2] ? argv[2][0] : hyphen;
-  if (check1 != hyphen) {
-    ug_PATH = argv[1];
-  }
-  if (check2 != hyphen) {
-    ug_OUTPATH = argv[2];
-  }
-
   int c;
   while (1)
     {
@@ -145,12 +135,16 @@ int main (int argc, char *argv[]) {
     {
       printf ("non-option ARGV-elements: ");
       while (optind < argc)
-        printf ("%s ", argv[optind++]);
-      putchar ('\n');
+        pushArg(&ug_args, argv[optind++]);
     }
 
   /** set default values if not included in flags **/
-
+  if (ug_args) {
+    ug_OUTPATH = ug_args->val;
+    if (ug_args->next) {
+      ug_PATH = ug_args->next->val;
+    }
+  }
   ug_maxnodes = ug_maxnodes ? ug_maxnodes : MAX_NODES;
   ug_maxedges = ug_maxedges ? ug_maxedges : MAX_EDGES;
   ug_percent = ug_percent ? ug_percent : 0.00;

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -48,7 +48,6 @@ bool ug_quickrun = false;
 /** Print out helper messages **/
 bool ug_verbose = false;
 const char hyphen = '-';
-char* checkHyphen;
 
 int main (int argc, char *argv[]) {
   int c;
@@ -140,12 +139,12 @@ int main (int argc, char *argv[]) {
 
   /** set default values if not included in flags **/
   if (ug_args) {
-    ug_OUTPATH = ug_args->val;
+    ug_OUTARG = ug_args->val;
     if (ug_args->next) {
       ug_PATH = ug_args->next->val;
     } else {
-      ug_PATH = ug_OUTPATH;
-      ug_OUTPATH = NULL;
+      ug_PATH = ug_OUTARG;
+      ug_OUTARG = NULL;
     }
   }
   ug_maxnodes = ug_maxnodes ? ug_maxnodes : MAX_NODES;
@@ -154,11 +153,16 @@ int main (int argc, char *argv[]) {
   ug_methods = ug_methods ? ug_methods : "d";
   FILEPATH = ug_INPUT ? ug_INPUT : ug_PATH;
   FILEPATH = FILEPATH ? FILEPATH : "src/resources/cpp2.graphml";
-  ug_FILENAME = FILEPATH ? basename(FILEPATH) : "FILE";
-  ug_DIRECTORY = FILEPATH ? dirname(FILEPATH) : "./";
-  if (ug_OUTPATH) {
-    ug_OUTFILE = (ug_OUTPATH[strlen(ug_OUTPATH)-1] != '/') ? basename(ug_OUTPATH) : ug_FILENAME;
-    ug_OUTPATH = (ug_OUTPATH[strlen(ug_OUTPATH)-1] == '/') ? ug_OUTPATH : strncat(dirname(ug_OUTPATH), "/", 2);
+  get_filename(FILEPATH, &ug_FILENAME);
+  ug_FILENAME = ug_FILENAME ? ug_FILENAME : "FILE";
+  get_directory(FILEPATH, &ug_DIRECTORY);
+  ug_DIRECTORY = ug_DIRECTORY ? ug_DIRECTORY : "./";
+  if (ug_OUTARG) {
+    printf("OUTARG:%s\n", ug_OUTARG);
+    get_filename(ug_OUTARG, &ug_OUTFILE);
+    ug_OUTFILE = ug_OUTFILE ? ug_OUTFILE : ug_FILENAME;
+    get_directory(ug_OUTARG, &ug_OUTPATH);
+    ug_OUTPATH = ug_OUTPATH ? ug_OUTPATH : "./OUT/";
   } else {
     ug_OUTPATH = "./OUT/";
     ug_OUTFILE = ug_FILENAME;

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -151,10 +151,15 @@ int main (int argc, char *argv[]) {
   ug_methods = ug_methods ? ug_methods : "d";
   FILEPATH = ug_INPUT ? ug_INPUT : ug_PATH;
   FILEPATH = FILEPATH ? FILEPATH : "src/resources/cpp2.graphml";
-  printf("\n%s\n", FILEPATH);
   ug_FILENAME = FILEPATH ? basename(FILEPATH) : "FILE";
   ug_DIRECTORY = FILEPATH ? dirname(FILEPATH) : "./";
-  ug_OUTPATH = ug_OUTPATH ? ug_OUTPATH : "OUT/";
+  if (ug_OUTPATH) {
+    ug_OUTFILE = (ug_OUTPATH[strlen(ug_OUTPATH)-1] != '/') ? basename(ug_OUTPATH) : ug_FILENAME;
+    ug_OUTPATH = (ug_OUTPATH[strlen(ug_OUTPATH)-1] == '/') ? ug_OUTPATH : strncat(dirname(ug_OUTPATH), "/", 1);
+  } else {
+    ug_OUTPATH = "OUT/";
+    ug_OUTFILE = ug_FILENAME;
+  }
 
   /** start output description **/
   if (ug_verbose == true) {

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -176,8 +176,9 @@ int main (int argc, char *argv[]) {
   }
   load_graph(FILEPATH);
   free(FILEPATH);
-  if (igraph_vcount(&g) > MAX_NODES) {
-    printf ("FAIL >>> Graphpass can only conduct analysis on graphs with fewer than %i nodes.\n", MAX_NODES);
+  if (igraph_vcount(&g) > MAX_NODES || igraph_ecount(&g) > MAX_EDGES){
+    printf ("FAIL >>> Graphpass can only conduct analysis on graphs with \
+    fewer than %i nodes and %i edges.\n", MAX_NODES, MAX_EDGES);
     printf ("FAIL >>> Exiting...\n");
     exit(EXIT_FAILURE);
   }

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -47,11 +47,19 @@ bool ug_report = false;
 bool ug_quickrun = false;
 /** Print out helper messages **/
 bool ug_verbose = false;
+const char hyphen = '-';
+char check1;
+char check2;
 
 int main (int argc, char *argv[]) {
-  /* Experiments here
-
-   End experiments */
+  check1 = argv[1] ? argv[1][0] : hyphen;
+  check2 = argv[2] ? argv[2][0] : hyphen;
+  if (check1 != hyphen) {
+    ug_PATH = argv[1];
+  }
+  if (check2 != hyphen) {
+    ug_OUTPATH = argv[2];
+  }
 
   int c;
   while (1)
@@ -61,12 +69,14 @@ int main (int argc, char *argv[]) {
           /* These options have no required argument */
           {"gexf",    no_argument,       0, 'g'},
           {"no-save", no_argument,       0, 'n'},
-          {"verbose", no_argument,       0, 'v'},
           {"quick",   no_argument,       0, 'q'},
           {"report",  no_argument,       0, 'r'},
+          {"verbose", no_argument,       0, 'v'},
 
           /* These options require an argument */
+          {"input", required_argument, 0, 'i'},
           {"methods", required_argument, 0, 'm'},
+          {"output",  required_argument, 0, 'o'},
           {"percent", required_argument, 0, 'p'},
           {"max-nodes", required_argument, 0, 'x'},
           {"max-edges", required_argument, 0, 'y'},
@@ -74,7 +84,7 @@ int main (int argc, char *argv[]) {
         };
       /* getopt_long stores the option index here. */
       int option_index = 0;
-      c = getopt_long (argc, argv, "gnvqrm:p:x:y:",
+      c = getopt_long (argc, argv, "gnvqri:m:o:p:x:y:",
                        long_options, &option_index);
 
       /* Detect the end of the options. */
@@ -86,29 +96,35 @@ int main (int argc, char *argv[]) {
           /* If this option set a flag, do nothing else now. */
           if (long_options[option_index].flag != 0)
             break;
-        case 'v':
-          ug_verbose = true;
-          break;
         case 'n':
           ug_save = !ug_save;
           break;
         case 'g':
           ug_gformat = !ug_gformat;
           break;
+        case 'i':
+          ug_INPUT = optarg ? optarg : "./";
+          break;
         case 'r':
           ug_report = !ug_report;
           break;
-        case 'p':
-          ug_percent = optarg ? atof(optarg) : 0.0;
-          break;
         case 'm':
           ug_methods = optarg ? optarg : "d";
+          break;
+        case 'o':
+          ug_OUT = optarg ? optarg : "./";
+          break;
+        case 'p':
+          ug_percent = optarg ? atof(optarg) : 0.0;
           break;
         case 'q':
           ug_quickrun = !ug_quickrun;
           break;
         case 'w':
           CALC_WEIGHTS = !CALC_WEIGHTS;
+          break;
+        case 'v':
+          ug_verbose = true;
           break;
         case 'x':
           ug_maxnodes = optarg ? (long)strtol(optarg, (char**)NULL, 10) : MAX_NODES;
@@ -127,8 +143,6 @@ int main (int argc, char *argv[]) {
   /* Print any remaining command line arguments (not options). */
   if (optind < argc)
     {
-      ug_PATH = argv[0] ? argv[0] : "./";
-      ug_OUTPATH = argv[1] ? argv[1] : "./";
       printf ("non-option ARGV-elements: ");
       while (optind < argc)
         printf ("%s ", argv[optind++]);
@@ -136,15 +150,17 @@ int main (int argc, char *argv[]) {
     }
 
   /** set default values if not included in flags **/
+
   ug_maxnodes = ug_maxnodes ? ug_maxnodes : MAX_NODES;
   ug_maxedges = ug_maxedges ? ug_maxedges : MAX_EDGES;
   ug_percent = ug_percent ? ug_percent : 0.00;
   ug_methods = ug_methods ? ug_methods : "d";
-  FILEPATH = ug_PATH ? ug_PATH : "src/resources/cpp2.graphml";
-  ug_FILENAME = ug_PATH ? basename(ug_PATH) : "FILE";
-  ug_DIRECTORY = ug_PATH ? dirname(ug_PATH) : "./";
-  ug_OUTPATH = ug_OUTPATH ? dirname(ug_OUTPATH) : ug_DIRECTORY;
-  ug_OUTPUT = ug_OUTPATH ? basename(ug_OUTPATH) : ug_FILENAME;
+  FILEPATH = ug_INPUT ? ug_INPUT : ug_PATH;
+  FILEPATH = FILEPATH ? FILEPATH : "src/resources/cpp2.graphml";
+  printf("\n%s\n", FILEPATH);
+  ug_FILENAME = FILEPATH ? basename(FILEPATH) : "FILE";
+  ug_DIRECTORY = FILEPATH ? dirname(FILEPATH) : "./";
+  ug_OUTPATH = ug_OUTPATH ? ug_OUTPATH : "OUT/";
 
   /** start output description **/
   if (ug_verbose == true) {

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -46,8 +46,10 @@ extern int load_graph (char* filename) {
   }
   igraph_read_graph_graphml(&g, fp, 0);
   NODESIZE = igraph_vcount(&g);
+  EDGESIZE = igraph_ecount(&g);
   if (ug_verbose) {
-    printf("Successfully ingested graph with %li nodes.\n", (long int)NODESIZE);
+    printf("Successfully ingested graph with %li nodes and %li edges.\n"
+    , (long int)NODESIZE, (long int)EDGESIZE);
   }
   fclose(fp);
   return (0);
@@ -102,4 +104,3 @@ extern int write_graph(igraph_t *graph, char *attr) {
   }
   return 0;
 }
-

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -22,6 +22,37 @@
 
 #include <graphpass.h>
 
+/** \fn get_directory
+    \brief gets the directory from a path (not using libgen)
+    @param path - path to extract the directory
+ */
+int get_directory (char *path, char **result) {
+  if (strlen(path) > 499){
+    printf("ERROR: Maximum characters in an outpath is 500.\n");
+    exit(EXIT_FAILURE);
+  }
+   static char temppath[500];
+   char *temp;
+   if (path[strlen(path)-1] ==  '/') {
+     *result = path;
+   } else {
+     strncpy(temppath, path, strlen(path)+1);
+     temp = strrchr(temppath, '/') + 1;
+     *temp = '\0';
+     *result = temppath;
+   }
+   return 0;
+ }
+
+int get_filename (char *path, char **result) {
+  char *temp;
+  if (path[strlen(path)-1] != '/') {
+    temp = strrchr(path, '/') + 1;
+    *result = temp;
+  }
+  return 0;
+}
+
 
 /** \fn strip_ext
     \brief strips the file extension from a filename
@@ -82,7 +113,7 @@ extern int write_graph(igraph_t *graph, char *attr) {
   char path[250];
   char perc_as_string[3];
   int perc = (int)ug_percent;
-  strncpy(fn, ug_OUTFILE, strlen(ug_OUTFILE));
+  strncpy(fn, ug_OUTFILE, strlen(ug_OUTFILE)+1);
   if(strstr(fn, ".") != NULL) {
     strip_ext(fn);
   }

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -76,16 +76,16 @@ extern int write_graph(igraph_t *graph, char *attr) {
   FILE *fp;
   char fn[strlen(ug_FILENAME)+1];
   struct stat st = {0};
-  if (stat(ug_OUTPUT, &st) == -1) {
-    mkdir(ug_OUTPUT, 0700);
+  if (stat(ug_OUTPATH, &st) == -1) {
+    mkdir(ug_OUTPATH, 0700);
   }
-  char path[150];
+  char path[250];
   char perc_as_string[3];
   int perc = (int)ug_percent;
   strncpy(fn, ug_FILENAME, strlen(ug_FILENAME));
   strip_ext(fn);
   snprintf(perc_as_string, 3, "%d", perc);
-  strncpy(path, ug_OUTPUT, strlen(ug_OUTPUT)+1);
+  strncpy(path, ug_OUTPATH, strlen(ug_OUTPATH)+1);
   strncat(path, fn, (strlen(fn)+1));
   if (ug_quickrun == false) {
     strncat(path, perc_as_string, 3);

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -74,7 +74,7 @@ extern int load_graph (char* filename) {
 
 extern int write_graph(igraph_t *graph, char *attr) {
   FILE *fp;
-  char fn[strlen(ug_FILENAME)+1];
+  char fn[strlen(ug_OUTFILE)+1];
   struct stat st = {0};
   if (stat(ug_OUTPATH, &st) == -1) {
     mkdir(ug_OUTPATH, 0700);
@@ -82,8 +82,10 @@ extern int write_graph(igraph_t *graph, char *attr) {
   char path[250];
   char perc_as_string[3];
   int perc = (int)ug_percent;
-  strncpy(fn, ug_FILENAME, strlen(ug_FILENAME));
-  strip_ext(fn);
+  strncpy(fn, ug_OUTFILE, strlen(ug_OUTFILE));
+  if(strstr(fn, ".") != NULL) {
+    strip_ext(fn);
+  }
   snprintf(perc_as_string, 3, "%d", perc);
   strncpy(path, ug_OUTPATH, strlen(ug_OUTPATH)+1);
   strncat(path, fn, (strlen(fn)+1));
@@ -101,10 +103,18 @@ extern int write_graph(igraph_t *graph, char *attr) {
       printf("Writing output to: %s\n", path);
     }
     fp = fopen(path, "w");
-    if (ug_gformat) {
-      igraph_write_graph_gexf(graph, fp, 1);
+    if (fp) {
+      if (ug_gformat) {
+        igraph_write_graph_gexf(graph, fp, 1);
+      } else {
+        igraph_write_graph_graphml(graph, fp, 1);
+      }
     } else {
-      igraph_write_graph_graphml(graph, fp, 1);
+      printf ("\n ERROR: Output path %s could not be accessed. Graphpass", ug_OUTPATH);
+      printf ("\n        cannot create more than one directory in your outpath.");
+      printf ("\n        If you require additional directories, please create them");
+      printf ("\n        before running graphpass.\n\n");
+      exit(EXIT_FAILURE);
     }
     fclose(fp);
   }

--- a/src/main/reports.c
+++ b/src/main/reports.c
@@ -50,6 +50,15 @@ int pushRank (struct RankNode** head_ref, int rankids[20]) {
   return 0;
 }
 
+/** adds a new value to Argument **/
+int pushArg (struct Argument** arg, char *value) {
+  struct Argument* newArg = (struct Argument*) malloc(sizeof(struct Argument));
+  newArg->val = value;
+  newArg->next = (*arg);
+  (*arg) = newArg;
+  return 0;
+}
+
 /** Does a rank-order test on two graphs, bassed on attribute **/
 int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv, igraph_real_t* result_ts ) {
   igraph_vector_t rank1, rank2, idRef1, idRef2, checkRef;
@@ -199,5 +208,3 @@ int write_report(igraph_t *graph) {
 int pvalues_to_csv (){
   return 0;
   };
-
-

--- a/src/main/reports.c
+++ b/src/main/reports.c
@@ -103,14 +103,11 @@ int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv
       check++;
     }
   }
-  printf("Check okay? %i\n", igraph_vector_all_e(&checkRef, &idRef2));
-  printf("Rank1 & Rank2 are the same? %i\n", igraph_vector_all_e(&rank1, &rank2));
   igraph_vector_destroy(&idRef2);
   igraph_vector_destroy(&idRef1);
   igraph_real_t pvalue;
   igraph_real_t tstat;
   paired_t_stat(&rank1, &rank2, &pvalue, &tstat);
-  printf("\npvalue: %f\n", pvalue);
   *result_pv = pvalue;
   *result_ts = tstat;
   igraph_vector_destroy(&rank2);

--- a/src/tests/quickrun_test.c
+++ b/src/tests/quickrun_test.c
@@ -28,7 +28,7 @@ void setUp() {
   ug_quickrun = true;
   ug_save = false;
   ug_FILENAME = "cpp2.graphml";
-  ug_OUTPUT = "TEST_OUT_FOLDER/";
+  ug_OUTPATH = "TEST_OUT_FOLDER/";
   ug_percent = 0.0;
   ug_DIRECTORY = "src/resources/";
   ug_gformat = false;

--- a/src/tests/quickrun_test.c
+++ b/src/tests/quickrun_test.c
@@ -31,6 +31,7 @@ void setUp() {
   ug_OUTPATH = "TEST_OUT_FOLDER/";
   ug_percent = 0.0;
   ug_DIRECTORY = "src/resources/";
+  ug_OUTFILE = ug_FILENAME;
   ug_gformat = false;
 }
 


### PR DESCRIPTION

**GitHub issue(s)**:

#47

# What does this Pull Request do?

Creates a more straightforward stdin stdout procedure call.

e.g. `./graphpass /path/to/input/file /path/to/output/outfile -{flags}` will run graphpass on file and store it in outfile.

The stdin and stdout paths can appear anywhere in the expression (you can put {flags} or other options before, between or after the path calls. However, the order of stdin must come before stdout.

The `-i` or `--input` will override an stdin call.
The `-i` or `--output` will override a stdout call.

Both will have the same behavior as the above mentioned calls.

Graphpass will create an `output/` directory in the call `./graphpass /path/to/input/file /path/to/output/outfile -{flags}` but only if `/path/to/` exists. Otherwise it will throw an error
with a message to create `/path/to/`.

Any non-flag arguments beyond stdin and stdout will be ignored for now (although graphpass will store them for future use).

# How should this be tested?

A description of what steps someone could take to:
- graphpass should accept the stdin / stdout procedure described above.
- all tests should pass.
- it should accept the case where stdout does not exist.
- no filenames should continue to run the test graphml (currently cpp2.graph in /src/resources).

# Additional Notes:

As of writing, I realize that i need to update the documentation in README. I will also check the case where there is no stdout declared.

# Interested parties

@ianmilligan1 and @ruebot 

Thanks in advance for your help with the Archives Unleashed Project!
