### PR TITLE
Change approach to input and output paths. Issue 47

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ OUT
 /tmp/
 *.swp
 .DS_Store
+/TEST_OUT_FOLDER/
+ana
+io
+qp

--- a/Makefile
+++ b/Makefile
@@ -35,22 +35,27 @@ release: src/main/graphpass.c
 debug: ./src/main/graphpass.c
 	gcc -g -Wall src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
 
-test: qp ana run clean
+test: qp ana io run clean
 
 qp: $(TEST_INCLUDE)runner_test_qp.c
-	gcc $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_qp.c $(DEPS) $(TEST_INCLUDE)quickrun_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o qp
+	gcc -g $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_qp.c $(DEPS) $(TEST_INCLUDE)quickrun_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o qp
 
 ana: $(TEST_INCLUDE)runner_test_ana.c
-	gcc $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_ana.c $(DEPS) $(TEST_INCLUDE)analyze_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o ana
+	gcc -g $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_ana.c $(DEPS) $(TEST_INCLUDE)analyze_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o ana
+
+io: $(TEST_INCLUDE)runner_test_io.c
+	gcc -g $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_io.c $(DEPS) $(TEST_INCLUDE)io_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o io
 
 run:
 	- ./ana
 	./qp
+	./io
 
 .PHONY : clean
 clean:
 	rm -f qp
 	rm -f ana
+	rm -f io
 	rm -rf TEST_OUT_FOLDER
 	rm -rf $(BUILD)
 	rm -f graphpass

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ INCLUDE = ./src/headers
 DEPS = -I$(INCLUDE) -I$(IGRAPH_INCLUDE) -I$(UNITY_INCLUDE)
 BUILD = build/
 
-all: test install
+all: clean test install
 
 install: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm -o graphpass

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,13 @@ debug: ./src/main/graphpass.c
 test: qp ana io run clean
 
 qp: $(TEST_INCLUDE)runner_test_qp.c
-	gcc -g $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_qp.c $(DEPS) $(TEST_INCLUDE)quickrun_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o qp
+	gcc $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_qp.c $(DEPS) $(TEST_INCLUDE)quickrun_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o qp
 
 ana: $(TEST_INCLUDE)runner_test_ana.c
-	gcc -g $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_ana.c $(DEPS) $(TEST_INCLUDE)analyze_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o ana
+	gcc $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_ana.c $(DEPS) $(TEST_INCLUDE)analyze_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o ana
 
 io: $(TEST_INCLUDE)runner_test_io.c
-	gcc -g $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_io.c $(DEPS) $(TEST_INCLUDE)io_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o io
+	gcc $(UNITY_INCLUDE)/unity.c $(TEST_INCLUDE)runner_test_io.c $(DEPS) $(TEST_INCLUDE)io_test.c $(HELPER_FILES) -L$(IGRAPH_LIB) -ligraph -lm -o io
 
 run:
 	- ./ana

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
-  IGRAPH_PATH = /usr/local/
+  BASE_PATH = /usr/local/
+  IGRAPH_PATH = $(BASE_PATH)
+	LIBGEN = -I/usr/include/
 endif
 ifeq ($(UNAME), Darwin)
   IGRAPH_PATH = /usr/local/Cellar/igraph/0.7.1_6/
@@ -18,21 +20,21 @@ TEST_INCLUDE = ./src/tests/
 TEST_RUNNER_PATH = ./src/tests/
 UNITY_INCLUDE = ./vendor/unity
 INCLUDE = ./src/headers
-DEPS = -I$(INCLUDE) -I$(IGRAPH_INCLUDE) -I$(UNITY_INCLUDE)
+DEPS = -I$(INCLUDE) -I$(IGRAPH_INCLUDE) -I$(UNITY_INCLUDE) $(LIBGEN)
 BUILD = build/
 
 all: test install
 
 install: src/main/graphpass.c
-	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
-	- ./graphpass -qn
+	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm -o graphpass
+	- ./graphpass -qnv
 
 release: src/main/graphpass.c
 	gcc src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
-	- ./graphpass -qg
+	- ./graphpass -qgnv
 
 debug: ./src/main/graphpass.c
-	gcc -g src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
+	gcc -g -Wall src/main/*.c $(DEPS) -L$(IGRAPH_LIB) -ligraph -lm  -o graphpass
 
 test: qp ana run clean
 
@@ -51,4 +53,5 @@ clean:
 	rm -f qp
 	rm -f ana
 	rm -rf TEST_OUT_FOLDER
+	rm -rf $(BUILD)
 	rm -f graphpass

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ UNAME := $(shell uname)
 ifeq ($(UNAME), Linux)
   BASE_PATH = /usr/local/
   IGRAPH_PATH = $(BASE_PATH)
-	LIBGEN = -I/usr/include/
 endif
 ifeq ($(UNAME), Darwin)
   IGRAPH_PATH = /usr/local/Cellar/igraph/0.7.1_6/
@@ -20,7 +19,7 @@ TEST_INCLUDE = ./src/tests/
 TEST_RUNNER_PATH = ./src/tests/
 UNITY_INCLUDE = ./vendor/unity
 INCLUDE = ./src/headers
-DEPS = -I$(INCLUDE) -I$(IGRAPH_INCLUDE) -I$(UNITY_INCLUDE) $(LIBGEN)
+DEPS = -I$(INCLUDE) -I$(IGRAPH_INCLUDE) -I$(UNITY_INCLUDE)
 BUILD = build/
 
 all: test install

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then
 
 ```
 cd graphpass
-make clean all
+make
 ```
 
 ## Usage
@@ -99,16 +99,16 @@ Once compiled use the following command:
 
 The following flags are available:
 
-* `--input {FILEPATH} or -i` - The filepath of the file to run Graphpass on. If not set, `graphpass` will use
+* `--input {FILEPATH} or -i` - The filepath of the file to run GraphPass on. If not set, GraphPass will use
 a default network in `src/resources`. This will override the value in `{INPUT PATH}`.
-* `--output {FILEPATH} or -o` - The filepath for outputs, overriding `{OUTPUT PATH}`. If the output path contains a filename, Graphpass will use that, otherwise it will default to the filename provided in `{INPUT PATH}`. Unless the quickpass (`-q`) is selected, the filename will also be altered to show the percentage filtered from the graph and the method used.
-* `--percent {PERCENT} or -p` - a percentage to remove from the file.  By default this is 0.0.
+* `--output {FILEPATH} or -o` - The filepath for outputs, overriding `{OUTPUT PATH}`. If the output path contains a filename, GraphPass will use that, otherwise it will default to the filename provided in `{INPUT PATH}`. Unless the quickpass (`-q`) is selected, the filename will also be altered to show the percentage filtered from the graph and the method used.
+* `--percent {PERCENT} or -p` - a percentage to remove from the file. By default this is 0.0.
 * `--method {options} or -m` - a string of various methods through which to filter the
 graph.
-* `--quick or -q` - Graphpass will run a basic set of algorithms for visualization with no filtering. The filename will be the same as the input filename.
-* `--gexf or -g` - Graphpass will return the graph output in gexf (good for SigmaJS) instead of graphml.
-* `--max-nodes {Value}` - Change default maximum number of nodes that graphpass will accept. By default this is 50,000. Values larger than 50k may cause graphpass to use up a computer's memory.
-* `--max-edges {Value}` - Change default maximum number of edges that graphpass will accept. By default this is 500,000. Values larger than 500k are unlikely to cause significant delays in computation time, but could result in memory issue upon visualization in Gephi or SigmaJS.
+* `--quick or -q` - GraphPass will run a basic set of algorithms for visualization with no filtering. The filename will be the same as the input filename.
+* `--gexf or -g` - GraphPass will return the graph output in gexf (good for SigmaJS) instead of graphml.
+* `--max-nodes {Value}` - Change default maximum number of nodes that GraphPass will accept. By default this is 50,000. Values larger than 50k may cause GraphPass to use up a computer's memory.
+* `--max-edges {Value}` - Change default maximum number of edges that GraphPass will accept. By default this is 500,000. Values larger than 500k are unlikely to cause significant delays in computation time, but could result in memory issue upon visualization in Gephi or SigmaJS.
 
 These various methods are outlined below:
 
@@ -125,10 +125,10 @@ These various methods are outlined below:
 For example:
 
 ```
-./graphpass /path/to/links-for-gephi.graphml --percent 10 --methods b /path/to/OUT/file
+./graphpass /path/to/links-for-gephi.graphml --percent 10 --methods b /path/to/output_filename
 ```
 
-Will remove 10% of the graph using betweenness as a cutting measure and lay the network out. It will find `links-for-gephi.graphml` file in `path/to` and output a new one to `/path/to/OUT` (titled `fileBetweenness.graphml`).
+Will remove 10% of the graph using betweenness as a cutting measure and lay the network out. It will find `links-for-gephi.graphml` file in `path/to/input` and output a new one to `/path/to/output_filename.graphml` (titled `output_filename10Betweenness.graphml`).
 
 # Optional arguments
 
@@ -137,7 +137,7 @@ Will remove 10% of the graph using betweenness as a cutting measure and lay the 
 
 # Troubleshooting
 
-It is possible that you can get a "error while loading shared libraries" error in Linux.  If so, try running `sudo ldconfig` to set the libraries path for your local installation of igraph.
+It is possible that you can get a "error while loading shared libraries" error in Linux. If so, try running `sudo ldconfig` to set the libraries path for your local installation of igraph.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then
 
 ```
 cd graphpass
-make
+make clean all
 ```
 
 ## Usage
@@ -94,18 +94,21 @@ make
 Once compiled use the following command:
 
 ```
-./graphpass {FLAGS}
+./graphpass {INPUT PATH} {OUTPUT PATH} {FLAGS}
 ```
 
 The following flags are available:
 
-* `--file {FILENAME}` - sets the default filename. If not set, `graphpass` will use
-a default network in `src/resources`.
-* `--dir {DIRECTORY}` - the path to look for {FILENAME} by default this is `src/resources/`
-* `--output {OUTPUT}` - the directory to send output files such as filtered graphs and data reports.
-* `--percent {PERCENT}` - a percentage to remove from the file.  By default this is 0.0.
-* `--method {options}` - a string of various methods through which to filter the
+* `--input {FILEPATH} or -i` - The filepath of the file to run Graphpass on. If not set, `graphpass` will use
+a default network in `src/resources`. This will override the value in `{INPUT PATH}`.
+* `--output {FILEPATH} or -o` - The filepath for outputs, overriding `{OUTPUT PATH}`. If the output path contains a filename, Graphpass will use that, otherwise it will default to the filename provided in `{INPUT PATH}`. Unless the quickpass (`-q`) is selected, the filename will also be altered to show the percentage filtered from the graph and the method used.
+* `--percent {PERCENT} or -p` - a percentage to remove from the file.  By default this is 0.0.
+* `--method {options} or -m` - a string of various methods through which to filter the
 graph.
+* `--quick or -q` - Graphpass will run a basic set of algorithms for visualization with no filtering. The filename will be the same as the input filename.
+* `--gexf or -g` - Graphpass will return the graph output in gexf (good for SigmaJS) instead of graphml.
+* `--max-nodes {Value}` - Change default maximum number of nodes that graphpass will accept. By default this is 50,000. Values larger than 50k may cause graphpass to use up a computer's memory.
+* `--max-edges {Value}` - Change default maximum number of edges that graphpass will accept. By default this is 500,000. Values larger than 500k are unlikely to cause significant delays in computation time, but could result in memory issue upon visualization in Gephi or SigmaJS.
 
 These various methods are outlined below:
 
@@ -122,17 +125,15 @@ These various methods are outlined below:
 For example:
 
 ```
-./graphpass --percent 10 --methods b --file links-for-gephi.graphml --output OUT/
+./graphpass /path/to/links-for-gephi.graphml --percent 10 --methods b /path/to/OUT/file
 ```
 
-Will remove 10% of the graph using betweenness as a cutting measure and lay the network out. It will find `links-for-gephi.graphml` file in `src/resources` and output a new one to `/OUT` (titled `links-for-gephi10Betweenness.graphml`).
+Will remove 10% of the graph using betweenness as a cutting measure and lay the network out. It will find `links-for-gephi.graphml` file in `path/to` and output a new one to `/path/to/OUT` (titled `fileBetweenness.graphml`).
 
 # Optional arguments
 
 * `--report` or `-r` : create an output report showing the impact of filtering on graph features.
 * `--no-save` or `-n` : does not save any filtered files (useful if you just want a report).
-* `--quick` or `-q` : provides a "quickrun" for basic
-* `--gexf` or `-g` : output as a .gexf (e.g. for SigmaJS inputs) instead of .graphml.
 
 # Troubleshooting
 

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -36,11 +36,17 @@ typedef enum { FAIL, WARN, COMM } broadcast;
 
 igraph_t g;
 igraph_attribute_table_t att;
-const char* ug_FILENAME; /**< The filename from -f flag. */
-const char* ug_DIRECTORY; /**< Directory to access FILENAME */
+
+char* ug_OUT; /**< A FILEPATH called using -o flag */
+char* ug_OUTFILE; /**< A FILENAME for outputting */
+char* ug_INPUT; /** A FILEPATH called using -i flag */
+char* ug_FILENAME; /**< FILENAME extracted from stdin path */
+char* ug_PATH; /**< Directory path extracted from stdin path */
 char* ug_methods;  /**< METHODS to filter */
-char* ug_OUTPUT;  /**< Folder to output new graphs */
-char* OUTPATH; /**< Path to output folder (DIRECTORY + OUTPUT) */
+char* ug_OUTPATH; /**< Path to output folder */
+char* ug_OUTPUT; /**< Filename extracted from outpath, if it exists. */
+char* ug_OUTARG; /**< Filepath entered as ARG */
+char* ug_DIRECTORY; /**< Directory extracted from ug_PATH */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
 igraph_integer_t EDGESIZE; /**< Number of Edges in original graph */
 float ug_percent; /**< Filtering percentage 0.0 by default */
@@ -87,6 +93,11 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
 
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 
+struct Argument {
+  char* val;
+  struct Argument *next;
+};
+
 struct Node {
   char* abbrev;
   igraph_real_t val;
@@ -120,6 +131,9 @@ struct Node* clustering;
 struct Node* pv;
 struct Node* ts;
 struct RankNode* ranks;
+struct Argument* ug_args;
+int get_directory (char *path, char **result);
+int get_filename (char *path, char **result);
 
 int shuffle(int *array, int n);
 /** adds a new value to a Node **/
@@ -128,6 +142,7 @@ int push(struct Node** head_ref, igraph_real_t value, char* attr);
 /** adds a new value to a RankNode **/
 int pushRank (struct RankNode** head_ref, int rankids[20]);
 int igraph_i_xml_escape(char* src, char** dest);
+int pushArg (struct Argument** arg, char *value);
 
 int igraph_write_graph_gexf(const igraph_t *graph, FILE *outstream,
                             igraph_bool_t prefixattr);

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -37,63 +37,63 @@ typedef enum { FAIL, WARN, COMM } broadcast;
 igraph_t g;
 igraph_attribute_table_t att;
 
-char* ug_OUT; /**< A FILEPATH called using -o flag */
-char* ug_OUTFILE; /**< A FILENAME for outputting */
-char* ug_INPUT; /** A FILEPATH called using -i flag */
-char* ug_FILENAME; /**< FILENAME extracted from stdin path */
-char* ug_PATH; /**< Directory path extracted from stdin path */
-char* ug_methods;  /**< METHODS to filter */
-char* ug_OUTPATH; /**< Path to output folder */
+char* ug_OUT; /**< A FILEPATH called using -o flag. */
+char* ug_OUTFILE; /**< A FILENAME for outputting. */
+char* ug_INPUT; /** A FILEPATH called using -i flag. */
+char* ug_FILENAME; /**< FILENAME extracted from stdin path. */
+char* ug_PATH; /**< Directory path extracted from stdin path. */
+char* ug_methods;  /**< METHODS to filter. */
+char* ug_OUTPATH; /**< Path to output folder. */
 char* ug_OUTPUT; /**< Filename extracted from outpath, if it exists. */
-char* ug_OUTARG; /**< Filepath entered as ARG */
+char* ug_OUTARG; /**< Filepath entered as ARG. */
 char* ug_DIRECTORY; /**< Directory extracted from ug_PATH. */
 bool ug_TEST; /**< Flags a test (ignores some expected FAIL messages). */
 igraph_integer_t NODESIZE; /**< Number of Nodes in original graph. */
 igraph_integer_t EDGESIZE; /**< Number of Edges in original graph. */
-float ug_percent; /**< Filtering percentage 0.0 by default */
-long ug_maxnodes; /**< user-defined max nodes for processing, default MAX_NODES */
-long ug_maxedges; /**< user-defined maxiumum edges for processing default MAX_EDGES */
-bool ug_report; /**< Include a report? */
-bool ug_gformat; /**< Graph format - true is "GEXF" false is "GRAPHML" */
-bool ug_quickrun; /**< Lightweight visualization run */
-bool ug_save; /**< If false, does not save graphs at all (for reports) */
+float ug_percent; /**< Filtering percentage 0.0 by default. */
+long ug_maxnodes; /**< user-defined max nodes for processing, default MAX_NODES. */
+long ug_maxedges; /**< user-defined maxiumum edges for processing default MAX_EDGES. */
+bool ug_report; /**< Include a report?. */
+bool ug_gformat; /**< Graph format - true is "GEXF" false is "GRAPHML." */
+bool ug_quickrun; /**< Lightweight visualization run. */
+bool ug_save; /**< If false, does not save graphs at all (for reports). */
 bool ug_verbose; //**< Verbose mode (default off). */
 bool CALC_WEIGHTS;
-igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
+igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis. */
 
-/* Required External libraries */
+/* Required External libraries. */
 
 #define PROGRAM_NAME "GraphPass"
 #define BUG_REPORT "https://www.github.com/archivesunleashed/graphpass/issues"
 #define GIT_REPOSITORY "https://www.github.com/archivesunleashed/graphpass"
 
-/* Color Presets */
+/* Color Presets. */
 
 #define COLOUR_SET_PASTEL "pastel.h"
 #define COLOUR_SET_PRIMARY "primary.h"
 #define COLOUR_SET_DAMPENED "dampened.h"
 
-/* Visualization Presets */
+/* Visualization Presets. */
 
-#define VIZ_SET_SPACIOUS "viz_spacious.h"
-#define VIZ_SET_LARGE "viz_large.h"
-#define VIZ_SET_SMALL "vis_small.h"
+#define VIZ_SET_SPACIOUS. "viz_spacious.h"
+#define VIZ_SET_LARGE. "viz_large.h"
+#define VIZ_SET_SMALL. "vis_small.h"
 
-/* Default Settings */
+/* Default Settings. */
 #define MAX_METHODS 9
 #define ALL_METHODS "abdehiopr"
 #define SIZE_DEFAULT "Degree"
 #define SIZE_DEFAULT_CHAR 'd'
 #define COLOR_BASE "WalkTrapModularity"
-#define PAGERANK_DAMPING 0.85 /**< chance random walk will not restart */
+#define PAGERANK_DAMPING 0.85 /**< chance random walk will not restart. */
 #define LAYOUT_DEFAULT_CHAR 'f'
-#define MAX_NODES 50000 /**< default number of nodes in graph before shut down */
-#define MAX_EDGES 500000 /**< default number of edges in graph before shut down */
+#define MAX_NODES 50000 /**< default number of nodes in graph before shut down. */
+#define MAX_EDGES 500000 /**< default number of edges in graph before shut down. */
 #define MAX_USER_EDGES 1000000000
 #define MAX_USER_NODES 1000000000
 
 /* For test suite */
-#define TEST_ARRAY_LENGTH 3 // update as you add test examples.
+#define TEST_ARRAY_LENGTH 3 // Update as you add test examples.
 #define TEST_MAX_STRING_SIZE 22
 #define TEST_FILENAME_SIZE 9
 
@@ -111,7 +111,7 @@ struct Node {
 };
 
 /** @struct RankNode
- @brief unimplemented struct for holding the top 20 rankids for the graph.
+ @brief Unimplemented struct for holding the top 20 rankids for the graph.
  */
 struct RankNode {
   int rankids[20];
@@ -142,10 +142,10 @@ int get_directory (char *path, char **result);
 int get_filename (char *path, char **result);
 
 int shuffle(int *array, int n);
-/** adds a new value to a Node **/
+/** Adds a new value to a Node. **/
 int push(struct Node** head_ref, igraph_real_t value, char* attr);
 
-/** adds a new value to a RankNode **/
+/** Adds a new value to a RankNode. **/
 int pushRank (struct RankNode** head_ref, int rankids[20]);
 int igraph_i_xml_escape(char* src, char** dest);
 int pushArg (struct Argument** arg, char *value);
@@ -160,7 +160,7 @@ igraph_real_t t_stat_vector(igraph_vector_t *v1);
 igraph_real_t t_test_vector(igraph_vector_t *v1, igraph_real_t df);
 
 int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv, igraph_real_t* result_ts );
-/** Writes the report **/
+/** Writes the report. **/
 int write_report(igraph_t *graph);
 int colors (igraph_t *graph);
 int layout_graph(igraph_t *graph, char layout);

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -91,6 +91,11 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis */
 #define MAX_USER_EDGES 1000000000
 #define MAX_USER_NODES 1000000000
 
+/* For test suite */
+#define TEST_ARRAY_LENGTH 3 // update as you add test examples.
+#define TEST_MAX_STRING_SIZE 22
+#define TEST_FILENAME_SIZE 9
+
 #define NELEMS(x)  (sizeof(x) / sizeof((x)[0]))
 
 struct Argument {

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -154,7 +154,7 @@ int igraph_write_graph_gexf(const igraph_t *graph, FILE *outstream,
 igraph_real_t mean_vector (igraph_vector_t *v1);
 igraph_real_t variance_vector (igraph_vector_t *v1);
 igraph_real_t std_vector(igraph_vector_t *v1);
-igraph_real_t stderror_vector(igraph_vector_t *v1);
+igraph_real_t std_error_vector(igraph_vector_t *v1);
 igraph_real_t t_stat_vector(igraph_vector_t *v1);
 igraph_real_t t_test_vector(igraph_vector_t *v1, igraph_real_t df);
 

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -75,9 +75,9 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis. */
 
 /* Visualization Presets. */
 
-#define VIZ_SET_SPACIOUS. "viz_spacious.h"
-#define VIZ_SET_LARGE. "viz_large.h"
-#define VIZ_SET_SMALL. "vis_small.h"
+#define VIZ_SET_SPACIOUS "viz_spacious.h"
+#define VIZ_SET_LARGE "viz_large.h"
+#define VIZ_SET_SMALL "vis_small.h"
 
 /* Default Settings. */
 #define MAX_METHODS 9

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -46,9 +46,10 @@ char* ug_methods;  /**< METHODS to filter */
 char* ug_OUTPATH; /**< Path to output folder */
 char* ug_OUTPUT; /**< Filename extracted from outpath, if it exists. */
 char* ug_OUTARG; /**< Filepath entered as ARG */
-char* ug_DIRECTORY; /**< Directory extracted from ug_PATH */
-igraph_integer_t NODESIZE; /**< Number of Nodes in original graph */
-igraph_integer_t EDGESIZE; /**< Number of Edges in original graph */
+char* ug_DIRECTORY; /**< Directory extracted from ug_PATH. */
+bool ug_TEST; /**< Flags a test (ignores some expected FAIL messages). */
+igraph_integer_t NODESIZE; /**< Number of Nodes in original graph. */
+igraph_integer_t EDGESIZE; /**< Number of Edges in original graph. */
 float ug_percent; /**< Filtering percentage 0.0 by default */
 long ug_maxnodes; /**< user-defined max nodes for processing, default MAX_NODES */
 long ug_maxedges; /**< user-defined maxiumum edges for processing default MAX_EDGES */

--- a/src/headers/graphpass.h
+++ b/src/headers/graphpass.h
@@ -39,7 +39,7 @@ igraph_attribute_table_t att;
 
 char* ug_OUT; /**< A FILEPATH called using -o flag. */
 char* ug_OUTFILE; /**< A FILENAME for outputting. */
-char* ug_INPUT; /** A FILEPATH called using -i flag. */
+char* ug_INPUT; /**< A FILEPATH called using -i flag. */
 char* ug_FILENAME; /**< FILENAME extracted from stdin path. */
 char* ug_PATH; /**< Directory path extracted from stdin path. */
 char* ug_methods;  /**< METHODS to filter. */
@@ -92,7 +92,7 @@ igraph_vector_t WEIGHTED; /**< If greater than 0, conducts weighted analysis. */
 #define MAX_USER_EDGES 1000000000
 #define MAX_USER_NODES 1000000000
 
-/* For test suite */
+/* For test suite. */
 #define TEST_ARRAY_LENGTH 3 // Update as you add test examples.
 #define TEST_MAX_STRING_SIZE 22
 #define TEST_FILENAME_SIZE 9

--- a/src/main/analyze.c
+++ b/src/main/analyze.c
@@ -49,12 +49,12 @@ igraph_real_t std_vector(igraph_vector_t *v1) {
   return sqrt(variance_vector(v1));
 }
 
-igraph_real_t stderror_vector(igraph_vector_t *v1) {
+igraph_real_t std_error_vector(igraph_vector_t *v1) {
   return (std_vector(v1) / sqrt(igraph_vector_size(v1)));
 }
 
 igraph_real_t t_stat_vector(igraph_vector_t *v1) {
-  return (mean_vector(v1)/stderror_vector(v1));
+  return (mean_vector(v1)/std_error_vector(v1));
 }
 
 igraph_real_t t_test_vector(igraph_vector_t *v1, igraph_real_t df) {
@@ -531,4 +531,3 @@ int create_graph_csv(char* filepath, int start, int perc) {
   fclose(fs);
   return 0;
 }
-

--- a/src/main/filter.c
+++ b/src/main/filter.c
@@ -325,7 +325,3 @@ int filter_graph() {
   igraph_vector_destroy(&idRef);
   return 0;
 }
-
-
-
-

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -47,6 +47,9 @@ bool ug_report = false;
 bool ug_quickrun = false;
 /** Print out helper messages **/
 bool ug_verbose = false;
+/** Not a test file */
+bool ug_TEST = false;
+
 const char hyphen = '-';
 
 int main (int argc, char *argv[]) {
@@ -166,7 +169,8 @@ int main (int argc, char *argv[]) {
     ug_OUTFILE = ug_FILENAME;
   }
 
-  if(strcmp(ug_OUTFILE, ug_FILENAME) == 0 && strcmp(ug_OUTPATH, ug_DIRECTORY) == 0) {
+  if(strcmp(ug_OUTFILE, ug_FILENAME) == 0
+    && strcmp(ug_OUTPATH, ug_DIRECTORY) == 0) {
     fprintf(stderr, "FAIL >>> Input and output locations cannot be the same.\n");
     fprintf(stderr, "FAIL >>> Exiting...\n");
     exit(EXIT_FAILURE);

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -165,9 +165,9 @@ int main (int argc, char *argv[]) {
     ug_OUTPATH = "./";
     ug_OUTFILE = ug_FILENAME;
   }
-
-  if(ug_OUTFILE == ug_FILENAME && ug_OUTPATH == FILEPATH) {
-    printf ("FAIL >>> Input and output locations cannot be the same.");
+  
+  if(strcmp(ug_OUTFILE, ug_FILENAME) == 0 && strcmp(ug_OUTPATH, ug_DIRECTORY) == 0) {
+    printf ("FAIL >>> Input and output locations cannot be the same.\n");
     printf ("FAIL >>> Exiting...\n");
     exit(EXIT_FAILURE);
   }

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -165,7 +165,7 @@ int main (int argc, char *argv[]) {
     ug_OUTPATH = "./";
     ug_OUTFILE = ug_FILENAME;
   }
-  
+
   if(strcmp(ug_OUTFILE, ug_FILENAME) == 0 && strcmp(ug_OUTPATH, ug_DIRECTORY) == 0) {
     printf ("FAIL >>> Input and output locations cannot be the same.\n");
     printf ("FAIL >>> Exiting...\n");
@@ -185,7 +185,11 @@ int main (int argc, char *argv[]) {
   if (ug_verbose == true) {
     printf("Running graphpass on file: %s\n", FILEPATH);
   }
-  load_graph(FILEPATH);
+  int load = load_graph(FILEPATH);
+  if (load != 0) {
+    printf("FAIL >>> Graphpass could not load the graph.");
+    exit(EXIT_FAILURE);
+  }
   if (igraph_vcount(&g) > ug_maxnodes || igraph_ecount(&g) > ug_maxedges){
     printf ("FAIL >>> Graphpass can only conduct analysis on graphs with \
 fewer than %li nodes and %li edges.\n", ug_maxnodes, ug_maxedges);

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -132,7 +132,6 @@ int main (int argc, char *argv[]) {
   /* Print any remaining command line arguments (not options). */
   if (optind < argc)
     {
-      printf ("non-option ARGV-elements: ");
       while (optind < argc)
         pushArg(&ug_args, argv[optind++]);
     }
@@ -158,14 +157,19 @@ int main (int argc, char *argv[]) {
   get_directory(FILEPATH, &ug_DIRECTORY);
   ug_DIRECTORY = ug_DIRECTORY ? ug_DIRECTORY : "./";
   if (ug_OUTARG) {
-    printf("OUTARG:%s\n", ug_OUTARG);
     get_filename(ug_OUTARG, &ug_OUTFILE);
     ug_OUTFILE = ug_OUTFILE ? ug_OUTFILE : ug_FILENAME;
     get_directory(ug_OUTARG, &ug_OUTPATH);
-    ug_OUTPATH = ug_OUTPATH ? ug_OUTPATH : "./OUT/";
+    ug_OUTPATH = ug_OUTPATH ? ug_OUTPATH : "./";
   } else {
-    ug_OUTPATH = "./OUT/";
+    ug_OUTPATH = "./";
     ug_OUTFILE = ug_FILENAME;
+  }
+
+  if(ug_OUTFILE == ug_FILENAME && ug_OUTPATH == FILEPATH) {
+    printf ("FAIL >>> Input and output locations cannot be the same.");
+    printf ("FAIL >>> Exiting...\n");
+    exit(EXIT_FAILURE);
   }
 
   /** start output description **/

--- a/src/main/graphpass.c
+++ b/src/main/graphpass.c
@@ -167,8 +167,8 @@ int main (int argc, char *argv[]) {
   }
 
   if(strcmp(ug_OUTFILE, ug_FILENAME) == 0 && strcmp(ug_OUTPATH, ug_DIRECTORY) == 0) {
-    printf ("FAIL >>> Input and output locations cannot be the same.\n");
-    printf ("FAIL >>> Exiting...\n");
+    fprintf(stderr, "FAIL >>> Input and output locations cannot be the same.\n");
+    fprintf(stderr, "FAIL >>> Exiting...\n");
     exit(EXIT_FAILURE);
   }
 
@@ -187,13 +187,13 @@ int main (int argc, char *argv[]) {
   }
   int load = load_graph(FILEPATH);
   if (load != 0) {
-    printf("FAIL >>> Graphpass could not load the graph.");
+    fprintf(stderr, "FAIL >>> Graphpass could not load the graph.");
     exit(EXIT_FAILURE);
   }
   if (igraph_vcount(&g) > ug_maxnodes || igraph_ecount(&g) > ug_maxedges){
-    printf ("FAIL >>> Graphpass can only conduct analysis on graphs with \
+    fprintf(stderr, "FAIL >>> Graphpass can only conduct analysis on graphs with \
 fewer than %li nodes and %li edges.\n", ug_maxnodes, ug_maxedges);
-    printf ("FAIL >>> Exiting...\n");
+    fprintf(stderr, "FAIL >>> Exiting...\n");
     exit(EXIT_FAILURE);
   }
 

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -25,6 +25,7 @@
 /** \fn get_directory
     \brief gets the directory from a path (not using libgen)
     @param path - path to extract the directory
+    @param result - empty string pointer to put the result.
  */
 int get_directory (char *path, char **result) {
   if (strlen(path) > 499){
@@ -47,7 +48,11 @@ int get_directory (char *path, char **result) {
    }
    return 0;
  }
-
+ /** \fn get_filename
+     \brief gets the filename from a path (not using libgen)
+     @param path - path to extract the directory
+     @param result - empty string pointer to place the result.
+  */
 int get_filename (char *path, char **result) {
   char *temp;
   if (path[strlen(path)-1] != '/') {

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -28,7 +28,7 @@
  */
 int get_directory (char *path, char **result) {
   if (strlen(path) > 499){
-    printf("ERROR: Maximum characters in an outpath is 500.\n");
+    fprintf(stderr, "ERROR: Maximum characters in an outpath is 500.\n");
     return(1);
   }
    static char temppath[500];
@@ -79,7 +79,7 @@ extern int load_graph (char* filename) {
   FILE *fp;
   fp = fopen(filename, "r");
   if (fp == 0) {
-    printf(">>> FAILURE - Could not find graphML file at filepath location.\n");
+    fprintf(stderr, ">>> FAILURE - Could not find graphML file at filepath location.\n");
     return (-1);
   }
   igraph_read_graph_graphml(&g, fp, 0);
@@ -109,8 +109,8 @@ extern int write_graph(igraph_t *graph, char *attr) {
   char fn[strlen(ug_OUTFILE)+1];
   struct stat st = {0};
   if (stat(ug_OUTPATH, &st) == -1) {
-    printf(">>> FAILURE - Could not create file at selected output location.\n");
-    printf(">>>         - Ensure that your assigned output folder exists.\n");
+    fprintf(stderr, ">>> FAILURE - Could not create file at selected output location.\n");
+    fprintf(stderr, ">>>         - Ensure that your assigned output folder exists.\n");
     return (-1);
   }
   char path[250];
@@ -144,10 +144,10 @@ extern int write_graph(igraph_t *graph, char *attr) {
         igraph_write_graph_graphml(graph, fp, 1);
       }
     } else {
-      printf ("\n ERROR: Output path %s could not be accessed. Graphpass", ug_OUTPATH);
-      printf ("\n        cannot create more than one directory in your outpath.");
-      printf ("\n        If you require additional directories, please create them");
-      printf ("\n        before running graphpass.\n\n");
+      fprintf (stderr, "\n ERROR: Output path %s could not be accessed. Graphpass", ug_OUTPATH);
+      fprintf (stderr, "\n        cannot create more than one directory in your outpath.");
+      fprintf (stderr, "\n        If you require additional directories, please create them");
+      fprintf (stderr, "\n        before running graphpass.\n\n");
       return(-1);
     }
     fclose(fp);

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -29,7 +29,7 @@
 int get_directory (char *path, char **result) {
   if (strlen(path) > 499){
     printf("ERROR: Maximum characters in an outpath is 500.\n");
-    exit(EXIT_FAILURE);
+    return(1);
   }
    static char temppath[500];
    char *temp;
@@ -54,7 +54,6 @@ int get_filename (char *path, char **result) {
   }
   return 0;
 }
-
 
 /** \fn strip_ext
     \brief strips the file extension from a filename

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -28,7 +28,9 @@
  */
 int get_directory (char *path, char **result) {
   if (strlen(path) > 499){
-    fprintf(stderr, "ERROR: Maximum characters in an outpath is 500.\n");
+    if (!ug_TEST) {
+      fprintf(stderr, "ERROR: Maximum characters in an outpath is 500.\n");
+    }
     return(1);
   }
    static char temppath[500];
@@ -79,7 +81,9 @@ extern int load_graph (char* filename) {
   FILE *fp;
   fp = fopen(filename, "r");
   if (fp == 0) {
-    fprintf(stderr, ">>> FAILURE - Could not find graphML file at filepath location.\n");
+    if (!ug_TEST) {
+      fprintf(stderr, ">>> FAILURE - Could not find graphML file at filepath location.\n");
+    }
     return (-1);
   }
   igraph_read_graph_graphml(&g, fp, 0);
@@ -109,8 +113,10 @@ extern int write_graph(igraph_t *graph, char *attr) {
   char fn[strlen(ug_OUTFILE)+1];
   struct stat st = {0};
   if (stat(ug_OUTPATH, &st) == -1) {
-    fprintf(stderr, ">>> FAILURE - Could not create file at selected output location.\n");
-    fprintf(stderr, ">>>         - Ensure that your assigned output folder exists.\n");
+    if (!ug_TEST) {
+      fprintf(stderr, ">>> FAILURE - Could not create file at selected output location.\n");
+      fprintf(stderr, ">>>         - Ensure that your assigned output folder exists.\n");
+    }
     return (-1);
   }
   char path[250];
@@ -144,10 +150,12 @@ extern int write_graph(igraph_t *graph, char *attr) {
         igraph_write_graph_graphml(graph, fp, 1);
       }
     } else {
-      fprintf (stderr, "\n ERROR: Output path %s could not be accessed. Graphpass", ug_OUTPATH);
-      fprintf (stderr, "\n        cannot create more than one directory in your outpath.");
-      fprintf (stderr, "\n        If you require additional directories, please create them");
-      fprintf (stderr, "\n        before running graphpass.\n\n");
+      if (!ug_TEST) {
+        fprintf (stderr, "\n ERROR: Output path %s could not be accessed. Graphpass", ug_OUTPATH);
+        fprintf (stderr, "\n        cannot create more than one directory in your outpath.");
+        fprintf (stderr, "\n        If you require additional directories, please create them");
+        fprintf (stderr, "\n        before running graphpass.\n\n");
+      }
       return(-1);
     }
     fclose(fp);

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -37,9 +37,11 @@ int get_directory (char *path, char **result) {
      *result = path;
    } else {
      strncpy(temppath, path, strlen(path)+1);
-     temp = strrchr(temppath, '/') + 1;
-     *temp = '\0';
-     *result = temppath;
+     temp = strpbrk(temppath, "/") ? strrchr(temppath, '/') + 1 : NULL;
+     if (temp) {
+       *temp = '\0';
+     }
+     *result = temp ? temppath : "./";
    }
    return 0;
  }
@@ -47,7 +49,7 @@ int get_directory (char *path, char **result) {
 int get_filename (char *path, char **result) {
   char *temp;
   if (path[strlen(path)-1] != '/') {
-    temp = strrchr(path, '/') + 1;
+    temp = strpbrk(path, "/") ? strrchr(path, '/') + 1 : path;
     *result = temp;
   }
   return 0;
@@ -108,7 +110,9 @@ extern int write_graph(igraph_t *graph, char *attr) {
   char fn[strlen(ug_OUTFILE)+1];
   struct stat st = {0};
   if (stat(ug_OUTPATH, &st) == -1) {
-    mkdir(ug_OUTPATH, 0700);
+    printf(">>> FAILURE - Could not create file at selected output location.\n");
+    printf(">>>         - Ensure that your assigned output folder exists.\n");
+    exit (-1);
   }
   char path[250];
   char perc_as_string[3];

--- a/src/main/io.c
+++ b/src/main/io.c
@@ -81,7 +81,7 @@ extern int load_graph (char* filename) {
   fp = fopen(filename, "r");
   if (fp == 0) {
     printf(">>> FAILURE - Could not find graphML file at filepath location.\n");
-    exit (-1);
+    return (-1);
   }
   igraph_read_graph_graphml(&g, fp, 0);
   NODESIZE = igraph_vcount(&g);
@@ -112,7 +112,7 @@ extern int write_graph(igraph_t *graph, char *attr) {
   if (stat(ug_OUTPATH, &st) == -1) {
     printf(">>> FAILURE - Could not create file at selected output location.\n");
     printf(">>>         - Ensure that your assigned output folder exists.\n");
-    exit (-1);
+    return (-1);
   }
   char path[250];
   char perc_as_string[3];
@@ -149,7 +149,7 @@ extern int write_graph(igraph_t *graph, char *attr) {
       printf ("\n        cannot create more than one directory in your outpath.");
       printf ("\n        If you require additional directories, please create them");
       printf ("\n        before running graphpass.\n\n");
-      exit(EXIT_FAILURE);
+      return(-1);
     }
     fclose(fp);
   }

--- a/src/main/reports.c
+++ b/src/main/reports.c
@@ -118,7 +118,9 @@ int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv
 /** Writes the report **/
 int write_report(igraph_t *graph) {
   if (ug_quickrun == true) { /*< QUICKRUN does not write a report */
-    fprintf(stderr, "No reports available for quickrun\n");
+    if (!ug_TEST) {
+      fprintf(stderr, "No reports available for quickrun\n");
+    }
     exit(0);
   }
   printf("Write report ... \n");

--- a/src/main/reports.c
+++ b/src/main/reports.c
@@ -50,6 +50,15 @@ int pushRank (struct RankNode** head_ref, int rankids[20]) {
   return 0;
 }
 
+/** adds a new value to Argument **/
+int pushArg (struct Argument** arg, char *value) {
+  struct Argument* newArg = (struct Argument*) malloc(sizeof(struct Argument));
+  newArg->val = value;
+  newArg->next = (*arg);
+  (*arg) = newArg;
+  return 0;
+}
+
 /** Does a rank-order test on two graphs, bassed on attribute **/
 int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv, igraph_real_t* result_ts ) {
   igraph_vector_t rank1, rank2, idRef1, idRef2, checkRef;
@@ -94,14 +103,11 @@ int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv
       check++;
     }
   }
-  printf("Check okay? %i\n", igraph_vector_all_e(&checkRef, &idRef2));
-  printf("Rank1 & Rank2 are the same? %i\n", igraph_vector_all_e(&rank1, &rank2));
   igraph_vector_destroy(&idRef2);
   igraph_vector_destroy(&idRef1);
   igraph_real_t pvalue;
   igraph_real_t tstat;
   paired_t_stat(&rank1, &rank2, &pvalue, &tstat);
-  printf("\npvalue: %f\n", pvalue);
   *result_pv = pvalue;
   *result_ts = tstat;
   igraph_vector_destroy(&rank2);
@@ -199,5 +205,3 @@ int write_report(igraph_t *graph) {
 int pvalues_to_csv (){
   return 0;
   };
-
-

--- a/src/main/reports.c
+++ b/src/main/reports.c
@@ -29,7 +29,7 @@
  @brief Holds graph level values for each graph that has been filtered.
  */
 
-/** adds a new value to a Node **/
+/** Adds a new value to a Node. **/
 int push(struct Node** head_ref, igraph_real_t value, char* attr)
 {
   struct Node* new_node = (struct Node*) malloc(sizeof(struct Node));
@@ -39,7 +39,7 @@ int push(struct Node** head_ref, igraph_real_t value, char* attr)
   (*head_ref) = new_node;
   return 0;
 }
-/** adds a new value to a RankNode **/
+/** Adds a new value to a RankNode. **/
 int pushRank (struct RankNode** head_ref, int rankids[20]) {
   struct RankNode* new_node = (struct RankNode*) malloc(sizeof(struct RankNode));
   for (int i=0; i<20; i++) {
@@ -50,7 +50,7 @@ int pushRank (struct RankNode** head_ref, int rankids[20]) {
   return 0;
 }
 
-/** adds a new value to Argument **/
+/** Adds a new value to argument. **/
 int pushArg (struct Argument** arg, char *value) {
   struct Argument* newArg = (struct Argument*) malloc(sizeof(struct Argument));
   newArg->val = value;
@@ -59,7 +59,7 @@ int pushArg (struct Argument** arg, char *value) {
   return 0;
 }
 
-/** Does a rank-order test on two graphs, bassed on attribute **/
+/** Does a rank-order test on two graphs, based on attribute. **/
 int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv, igraph_real_t* result_ts ) {
   igraph_vector_t rank1, rank2, idRef1, idRef2, checkRef;
   char attribute[strlen(attr) + 5];
@@ -115,7 +115,7 @@ int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv
 }
 
 
-/** Writes the report **/
+/** Writes the report. **/
 int write_report(igraph_t *graph) {
   if (ug_quickrun == true) { /*< QUICKRUN does not write a report */
     if (!ug_TEST) {

--- a/src/main/reports.c
+++ b/src/main/reports.c
@@ -67,14 +67,12 @@ int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv
   strncat(attribute, "Rank", 5);
   bool first = (igraph_vcount(g1) < igraph_vcount(g2));
   if (first){
-    printf("first");
     igraph_vector_init(&rank2, igraph_vcount(g1));
     igraph_vector_init(&rank1, igraph_vcount(g1));
     //idRefs should be shrunk to smaller size;
     igraph_vector_init(&idRef1, igraph_vcount(g2));
     igraph_vector_init(&idRef2, igraph_vcount(g1));
     igraph_vector_init(&checkRef, igraph_vcount(g1));
-    printf("Get attribute");
     VANV(g1, attribute, &rank2);
     VANV(g2, "idRef", &idRef1);
     VANV(g1, "idRef", &idRef2);
@@ -120,7 +118,7 @@ int rankCompare(igraph_t *g1, igraph_t *g2, char* attr, igraph_real_t* result_pv
 /** Writes the report **/
 int write_report(igraph_t *graph) {
   if (ug_quickrun == true) { /*< QUICKRUN does not write a report */
-    printf("No reports available for quickrun\n");
+    fprintf(stderr, "No reports available for quickrun\n");
     exit(0);
   }
   printf("Write report ... \n");

--- a/src/tests/analyze_test.c
+++ b/src/tests/analyze_test.c
@@ -98,7 +98,7 @@ void TEST_HUB_ALGORITHM() {
 void TEST_EIGENVECTOR_ALGORITHM() {
   TEST_IGNORE_MESSAGE("Eigenvector has some random elements that need to be seeded");
   TEST_IGNORE();
-  
+
   calc_eigenvector(&g);
   igraph_vector_t eig;
   igraph_vector_init(&eig, 0);
@@ -199,9 +199,9 @@ void TEST_STDERROR() {
   VECTOR(test)[3] = 6; VECTOR(test)[4] = 18; VECTOR(test)[5] = 17;
   VECTOR(test)[6] = 21; VECTOR(test)[7] = 23; VECTOR(test)[8] = 24;
   VECTOR(test)[9] = 33;
-  TEST_ASSERT_EQUAL_FLOAT(roundf(100000* stderror_vector(&test))/100000, 2.59251);
+  TEST_ASSERT_EQUAL_FLOAT(roundf(100000* std_error_vector(&test))/100000, 2.59251);
   VECTOR(test)[9] = 1000;
-  TEST_ASSERT_EQUAL_FLOAT(roundf(100000*stderror_vector(&test))/100000, 98.1571);
+  TEST_ASSERT_EQUAL_FLOAT(roundf(100000* std_error_vector(&test))/100000, 98.1571);
   igraph_vector_destroy(&test);
 }
 
@@ -230,5 +230,3 @@ void TEST_TPVALUE() {
   TEST_ASSERT_EQUAL_FLOAT(roundf(100000* t_test_vector(&test, 9))/100000, 0.26452);
   igraph_vector_destroy(&test);
 }
-
-

--- a/src/tests/io_test.c
+++ b/src/tests/io_test.c
@@ -1,0 +1,108 @@
+/*
+ * GraphPass:
+ * A utility to filter networks and provide a default visualization output
+ * for Gephi or SigmaJS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @file analyze_test.h
+ @brief Tests for analyze.h
+ */
+
+#include "graphpass.h"
+#include "unity.h"
+#include <math.h>
+
+// Constants
+const int ARRAY_LENGTH = 3; // update as you add test examples.
+const int MAX_STRING_SIZE = 22;
+const int FILENAME_SIZE = 9;
+char samp[ARRAY_LENGTH][MAX_STRING_SIZE] = {
+  "/path/to/a/directory/",
+  "/path/to/a/file.ext",
+  "file.ext"}, path[MAX_STRING_SIZE];
+
+void setUp(void) {
+}
+
+void tearDown(void) {
+}
+
+void TEST_GET_DIRECTORY() {
+  char expected[ARRAY_LENGTH][MAX_STRING_SIZE] = {
+    "/path/to/a/directory/",
+    "/path/to/a/",
+    "./"}, path[MAX_STRING_SIZE];
+  for (int i=0; i < ARRAY_LENGTH; i++) {
+    char *expect;
+    get_directory(samp[i], &expect);
+    TEST_ASSERT_EQUAL_STRING(expect, expected[i]);
+  }
+}
+
+void TEST_GET_FILE() {
+  for (int i=ARRAY_LENGTH-1; i < 0; i--) {
+    char expect[FILENAME_SIZE] = "file.ext";
+    char *result;
+    get_filename(samp[i], &result);
+    if (i > 0) {
+      TEST_ASSERT_EQUAL_STRING(result, expect);
+    } else { // last value should be null
+      TEST_ASSERT_NULL(result);
+    }
+  }
+}
+
+void TEST_STRIP_EXT() {
+  char expect[FILENAME_SIZE] = "file.ext";
+  char result[5] = "file";
+  strip_ext(expect);
+  TEST_ASSERT_EQUAL_STRING(&expect, result);
+}
+
+void TEST_LOAD_GRAPH() {
+  load_graph("src/resources/cpp2.graphml");
+  int fail = load_graph("fake/filepath.cpp2.graphml");
+  int success = load_graph("src/resources/cpp2.graphml");
+  TEST_ASSERT_EQUAL_INT(NODESIZE, 218);
+  TEST_ASSERT_EQUAL_INT(EDGESIZE, 220);
+  TEST_ASSERT_EQUAL_INT(fail, -1);
+  TEST_ASSERT_EQUAL_INT(success, 0);
+  igraph_destroy(&g);
+}
+
+void TEST_WRITE_GRAPH() {
+  struct stat st = {0};
+  ug_save = true;
+  ug_FILENAME = "cpp2.graphml";
+  ug_OUTPATH = "TEST_OUT_FOLDER/";
+  ug_percent = 0.0;
+  ug_DIRECTORY = "src/resources/";
+  ug_OUTFILE = ug_FILENAME;
+  ug_gformat = false;
+  if (stat(ug_OUTPATH, &st) == -1) {
+    mkdir(ug_OUTPATH, 0700);
+  }
+  igraph_t graph;
+  igraph_vector_t v;
+  igraph_real_t edges[] = {0,1,0,2,0,3};
+  igraph_vector_view(&v, edges, sizeof(edges)/sizeof(double));
+  igraph_create(&graph, &v, 0, IGRAPH_DIRECTED);
+  int success = write_graph(&graph, "hey");
+  ug_OUTPATH = "FAKE_TEST_OUT_FOLDER/";
+  int fail = write_graph(&graph, "hey");
+  TEST_ASSERT_EQUAL_INT(fail, -1);
+  TEST_ASSERT_EQUAL_INT(success, 0);
+  igraph_destroy(&graph);
+}

--- a/src/tests/io_test.c
+++ b/src/tests/io_test.c
@@ -25,13 +25,10 @@
 #include <math.h>
 
 // Constants
-const int ARRAY_LENGTH = 3; // update as you add test examples.
-const int MAX_STRING_SIZE = 22;
-const int FILENAME_SIZE = 9;
-char samp[ARRAY_LENGTH][MAX_STRING_SIZE] = {
+char samp[TEST_ARRAY_LENGTH][TEST_MAX_STRING_SIZE] = {
   "/path/to/a/directory/",
   "/path/to/a/file.ext",
-  "file.ext"}, path[MAX_STRING_SIZE];
+  "file.ext"}, path[TEST_MAX_STRING_SIZE];
 
 void setUp(void) {
 }
@@ -40,11 +37,11 @@ void tearDown(void) {
 }
 
 void TEST_GET_DIRECTORY() {
-  char expected[ARRAY_LENGTH][MAX_STRING_SIZE] = {
+  char expected[TEST_ARRAY_LENGTH][TEST_MAX_STRING_SIZE] = {
     "/path/to/a/directory/",
     "/path/to/a/",
-    "./"}, path[MAX_STRING_SIZE];
-  for (int i=0; i < ARRAY_LENGTH; i++) {
+    "./"}, path[TEST_MAX_STRING_SIZE];
+  for (int i=0; i < TEST_ARRAY_LENGTH; i++) {
     char *expect;
     get_directory(samp[i], &expect);
     TEST_ASSERT_EQUAL_STRING(expect, expected[i]);
@@ -52,8 +49,8 @@ void TEST_GET_DIRECTORY() {
 }
 
 void TEST_GET_FILE() {
-  for (int i=ARRAY_LENGTH-1; i < 0; i--) {
-    char expect[FILENAME_SIZE] = "file.ext";
+  for (int i=TEST_ARRAY_LENGTH-1; i < 0; i--) {
+    char expect[TEST_FILENAME_SIZE] = "file.ext";
     char *result;
     get_filename(samp[i], &result);
     if (i > 0) {
@@ -65,7 +62,7 @@ void TEST_GET_FILE() {
 }
 
 void TEST_STRIP_EXT() {
-  char expect[FILENAME_SIZE] = "file.ext";
+  char expect[TEST_FILENAME_SIZE] = "file.ext";
   char result[5] = "file";
   strip_ext(expect);
   TEST_ASSERT_EQUAL_STRING(&expect, result);

--- a/src/tests/quickrun_test.c
+++ b/src/tests/quickrun_test.c
@@ -25,6 +25,7 @@
 #include "graphpass.h"
 
 void setUp() {
+  struct stat st = {0};
   ug_quickrun = true;
   ug_save = false;
   ug_FILENAME = "cpp2.graphml";
@@ -33,6 +34,9 @@ void setUp() {
   ug_DIRECTORY = "src/resources/";
   ug_OUTFILE = ug_FILENAME;
   ug_gformat = false;
+  if (stat(ug_OUTPATH, &st) == -1) {
+    mkdir(ug_OUTPATH, 0700);
+  }
 }
 
 void TEST_QUICKRUN_NOSAVE() {

--- a/src/tests/quickrun_test.c
+++ b/src/tests/quickrun_test.c
@@ -28,9 +28,10 @@ void setUp() {
   ug_quickrun = true;
   ug_save = false;
   ug_FILENAME = "cpp2.graphml";
-  ug_OUTPUT = "TEST_OUT_FOLDER/";
+  ug_OUTPATH = "TEST_OUT_FOLDER/";
   ug_percent = 0.0;
   ug_DIRECTORY = "src/resources/";
+  ug_OUTFILE = ug_FILENAME;
   ug_gformat = false;
 }
 

--- a/src/tests/runner_test_ana.c
+++ b/src/tests/runner_test_ana.c
@@ -66,6 +66,7 @@ void resetTest(void)
 }
 
 int main (void) {
+  ug_TEST = true;
   ug_FILENAME = "cpp2.graphml";
   ug_OUTPUT = "TEST_OUT_FOLDER/";
   ug_percent = 0.0;

--- a/src/tests/runner_test_io.c
+++ b/src/tests/runner_test_io.c
@@ -56,6 +56,7 @@ void resetTest(void)
 }
 
 int main (void) {
+  ug_TEST = true;
   UnityBegin("src/tests/io_test.c");
   RUN_TEST(TEST_GET_DIRECTORY, 43);
   RUN_TEST(TEST_GET_FILE, 55);

--- a/src/tests/runner_test_io.c
+++ b/src/tests/runner_test_io.c
@@ -1,0 +1,66 @@
+/*
+ * GraphPass:
+ * A utility to filter networks and provide a default visualization output
+ * for Gephi or SigmaJS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define RUN_TEST(TestFunc, TestLineNum) \
+{ \
+Unity.CurrentTestName = #TestFunc; \
+Unity.CurrentTestLineNumber = TestLineNum; \
+Unity.NumberOfTests++; \
+if (TEST_PROTECT()) \
+{ \
+setUp(); \
+TestFunc(); \
+} \
+if (TEST_PROTECT()) \
+{ \
+tearDown(); \
+} \
+UnityConcludeTest(); \
+}
+
+#include "igraph.h"
+#include "unity.h"
+#include "unity_internals.h"
+#include "graphpass.h"
+#include "stdio.h"
+#include "string.h"
+
+extern void setUp(void);
+extern void tearDown(void);
+extern void TEST_GET_DIRECTORY(void);
+extern void TEST_GET_FILE(void);
+extern void TEST_STRIP_EXT(void);
+extern void TEST_LOAD_GRAPH(void);
+extern void TEST_WRITE_GRAPH(void);
+
+void resetTest(void);
+void resetTest(void)
+{
+  tearDown();
+  setUp();
+}
+
+int main (void) {
+  UnityBegin("src/tests/io_test.c");
+  RUN_TEST(TEST_GET_DIRECTORY, 43);
+  RUN_TEST(TEST_GET_FILE, 55);
+  RUN_TEST(TEST_STRIP_EXT, 68);
+  RUN_TEST(TEST_LOAD_GRAPH, 74);
+  RUN_TEST(TEST_WRITE_GRAPH, 85);
+  return (UNITY_END());
+}

--- a/src/tests/runner_test_qp.c
+++ b/src/tests/runner_test_qp.c
@@ -56,7 +56,7 @@ void resetTest(void)
 }
 
 int main (void) {
-  
+  ug_TEST = true;
   load_graph("src/resources/cpp2.graphml");
   UnityBegin("src/tests/quickrun_test.c");
   RUN_TEST(TEST_QUICKRUN_NOSAVE, 22);


### PR DESCRIPTION
**GitHub issue(s)**:

#47

# What does this Pull Request do?

- accept `./graphpass {input path} {output path} -flags --optionA {data}`
- input path and output path can be anywhere in command line, provided that input comes first and output comes second (other non-option args are ignored for now).
- include helper functions get_directory and get_filename.
- issue in comments of #62 regarding directories being created has NOT been addressed in this PR.

# How should this be tested?

- Should pass Travis.
- Should work in ubuntu (linux) and Mac.
- Tests should pass.
- `./graphpass {/path/to/file.graphml} {/path/to/output} -q` should do a quickpass to `output.graphml.`
- `./graphpass  {/path/to/file.graphml} {/path/to/output/} -qg`should do a quickpass to `file.gexf`

# Additional Notes:

`./graphpass {/path/to/file.graphml} {/path/to/} -q` may replace the input file `file.graphml` in current commits.  This will need to be repaired or managed (see comments in #62).

# Interested parties

@ianmilligan1 @ruebot 

Thanks in advance for your help with the Archives Unleashed Project!
