### PR TITLE
Remove graph attributes from gexf output (not supported by networkx). #68

### DIFF
--- a/src/main/gexf.c
+++ b/src/main/gexf.c
@@ -127,28 +127,6 @@ extern int igraph_write_graph_gexf(const igraph_t *graph, FILE *outstream,
   ret=fprintf(outstream, "  <graph id=\"G\" defaultedgetype=\"%s\">\x0A", (igraph_is_directed(graph)?"directed":"undirected"));
   if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
 
-  /* graph attributes */
-  ret=fprintf(outstream, "  <attributes class=\"graph\">\x0A");
-  if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
-  for (i=0; i<igraph_vector_size(&gtypes); i++) {
-    char *name, *name_escaped;
-    igraph_strvector_get(&gnames, i, &name);
-    IGRAPH_CHECK(igraph_i_xml_escape(name, &name_escaped));
-    if (VECTOR(gtypes)[i] == IGRAPH_ATTRIBUTE_STRING) {
-      ret=fprintf(outstream, "  <attribute id=\"%s%s\" title=\"%s\" type=\"string\"/>\x0A", gprefix, name_escaped, name_escaped);
-      if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
-    } else if (VECTOR(gtypes)[i] == IGRAPH_ATTRIBUTE_NUMERIC) {
-      ret=fprintf(outstream, "  <attribute id=\"%s%s\" title=\"%s\" type=\"double\"/>\x0A", gprefix, name_escaped, name_escaped);
-      if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
-    } else if (VECTOR(gtypes)[i] == IGRAPH_ATTRIBUTE_BOOLEAN) {
-      ret=fprintf(outstream, "  <attribute id=\"%s%s\" attr.title=\"%s\" type=\"boolean\"/>\x0A", gprefix, name_escaped, name_escaped);
-      if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
-    }
-    igraph_Free(name_escaped);
-  }
-  ret=fprintf(outstream, "  </attributes>\x0A");
-  if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);
-
   /* vertex attributes */
   ret=fprintf(outstream, "  <attributes class=\"node\">\x0A");
   if (ret<0) IGRAPH_ERROR("Write failed", IGRAPH_EFILE);


### PR DESCRIPTION
**GitHub issue(s)**:

#68 

# What does this Pull Request do?

Removes the graph attributes from the gexf output. 
Graph attributes are analyses about the entire graph (e.g. average density)
and are not supported in gexf.

# How should this be tested?

The best way to test this is to:
    - Output `./graphpass -qg {CollectionId}-gephi.graphml` on an existing graphml from auk to `{CollectionId}-gephi.gexf`
    - Add file to `data` folder to an [AUK-NOTEBOOKS](https://github.com/archivesunleashed/auk-notebooks/blob/master/AUK_Full-Text-collection_id.ipynb) instance.
    - Change `coll_id` to {CollectionId}
    - Run the first two windows + the last (network analysis) window. It should produce a graph.

# Additional Notes:

The following perl command will fix the problem with existing gexf files. This is a better option than try to redo files upstream.

`perl -0777 -i.original -pe 's/\s+<attributes class="graph">\s+<\/attributes>//' {CollectionId}-gephi.gexf`

(I tried to use sed, but multi-line find and replace got more complicated than I wanted it to be.)

# Interested parties

@ianmilligan1 @ruebot 

Thanks in advance for your help with the Archives Unleashed Project!
